### PR TITLE
Fix/ci docker buildx cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,27 @@
 # final aggregate gate fails the workflow if anomaly or any required job failed (nothing silently skipped).
 name: och-ci
 
-# pull_request: all PRs. push: default branch only — avoids duplicate runs on PR branches (push + PR
-# both firing → same concurrency group → cancel-in-progress kills the other run → mass Cancelled tests).
+# pull_request: all PRs. push: default + feature branches — pushes to fix/** etc. run CI without opening
+# a PR (push-only workflows were previously silent). Same concurrency group per branch still dedupes
+# overlapping push/PR syncs to one in-flight run.
 on:
   push:
-    branches: [main, master, develop]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
   pull_request:
 
-# Same branch name for pull_request (head) and push → one group cancels duplicate fires (PR sync used to
-# run both events with different keys and double every matrix job).
+# Include event_name so push and pull_request are separate groups: otherwise both use the same branch key
+# and cancel-in-progress kills the sibling run (integration tests cancelled, aggregate shows failed, PR
+# checks look missing or duplicated inconsistently).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/dev-onboard-lite.yml
+++ b/.github/workflows/dev-onboard-lite.yml
@@ -14,6 +14,28 @@ on:
       - 'Makefile'
       - 'diagrams/uml/**'
       - 'diagrams/c4/**'
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
+    paths:
+      - 'scripts/**'
+      - 'infra/k8s/**'
+      - 'Makefile'
+      - 'diagrams/uml/**'
+      - 'diagrams/c4/**'
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   validate-onboard:
@@ -27,7 +49,8 @@ jobs:
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
         with:
-          version: 'v1.29.0'
+          # v1.29 kustomize fails on multi-doc strategic-merge patches (e.g. overlays/dev/patches/e2e-high-cap-mode-env.yaml).
+          version: "v1.31.0"
 
       - name: Run dev-onboard-lite
         run: make dev-onboard-lite

--- a/.github/workflows/diagrams.yml
+++ b/.github/workflows/diagrams.yml
@@ -12,6 +12,27 @@ on:
       - "diagrams/uml/**"
       - "diagrams/c4/**"
       - "Makefile"
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
+    paths:
+      - "scripts/diagram/**"
+      - "scripts/diagram/data/**"
+      - "diagrams/theme.frag"
+      - "diagrams/uml/**"
+      - "diagrams/c4/**"
+      - "Makefile"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   diagrams:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,12 +4,21 @@ name: och-docker-build
 
 on:
   push:
-    branches: [main, master, develop]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
   pull_request:
+  workflow_dispatch:
 
 # Avoid starving other workflows: only N image builds at once (GitHub-hosted runner pool is shared).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -42,5 +51,6 @@ jobs:
           file: ${{ matrix.service == 'webapp' && 'webapp/Dockerfile' || format('services/{0}/Dockerfile', matrix.service) }}
           push: false
           tags: och-${{ matrix.service }}:ci
+          # Read GHA cache only; omit cache-to — exporting to results-receiver.actions.githubusercontent.com
+          # often hits DeadlineExceeded i/o timeouts and fails the whole job after a successful build.
           cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ephemeral-cluster.yml
+++ b/.github/workflows/ephemeral-cluster.yml
@@ -13,10 +13,29 @@ on:
       - "infra/k8s/metallb/**"
       - "Makefile"
       - ".github/workflows/ephemeral-cluster.yml"
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
+    paths:
       - "scripts/ci/**"
+      - "scripts/generate-canonical-dev-tls.sh"
+      - "scripts/tests/kafka-alignment-suite.sh"
+      - "scripts/kafka-runtime-sync.sh"
+      - "infra/k8s/metallb/**"
+      - "Makefile"
+      - ".github/workflows/ephemeral-cluster.yml"
+      - ".github/workflows/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -32,7 +51,7 @@ jobs:
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
         with:
-          version: "v1.29.0"
+          version: "v1.31.0"
 
       - name: Install k3s
         run: |
@@ -51,9 +70,9 @@ jobs:
           CI_MODE: "1"
         run: bash scripts/ci/ephemeral-k3s-converge.sh
 
-      - name: Kustomize client dry-run (housing base + dev)
+      - name: Kustomize build (base + dev; no apply dry-run on GHA)
         run: |
           set -euo pipefail
-          kubectl apply --dry-run=client -k infra/k8s/base -o name >/dev/null
-          kubectl apply --dry-run=client -k infra/k8s/overlays/dev -o name >/dev/null
-          echo "✅ housing kustomize client dry-run OK"
+          kubectl kustomize infra/k8s/base >/dev/null
+          kubectl kustomize infra/k8s/overlays/dev >/dev/null
+          echo "✅ housing kubectl kustomize OK (dev-onboard-lite already builds these; apply dry-run needs apiserver)"

--- a/.github/workflows/kafka-alignment.yml
+++ b/.github/workflows/kafka-alignment.yml
@@ -15,8 +15,18 @@ on:
       - "infra/k8s/kafka-ops/**"
       - "Makefile"
       - ".github/workflows/kafka-alignment.yml"
+      - ".github/workflows/docker-build.yml"
+      - "services/messaging-service/Dockerfile"
   push:
-    branches: [main, master, develop]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
     paths:
       - "scripts/tests/kafka-alignment-suite.sh"
       - "scripts/kafka-runtime-sync.sh"
@@ -29,6 +39,9 @@ on:
       - "infra/k8s/kafka-ops/**"
       - "Makefile"
       - ".github/workflows/kafka-alignment.yml"
+      - ".github/workflows/docker-build.yml"
+      - "services/messaging-service/Dockerfile"
+      - ".github/workflows/**"
   workflow_dispatch:
     inputs:
       run_live_suite:
@@ -38,7 +51,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -71,20 +84,35 @@ jobs:
           grep -q '^kafka-alignment-suite:' Makefile
           grep -q '^kafka-health:' Makefile
 
+  # Always runs (green) so PR/push checks are not "Skipped"; k3s + suite only when dispatch + input.
   live:
-    if: github.event_name == 'workflow_dispatch' && inputs.run_live_suite
+    needs: [static]
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: [static]
     steps:
       - uses: actions/checkout@v4
 
+      - name: Live suite gate (opt-in cluster work)
+        id: live
+        run: |
+          set -euo pipefail
+          if ${{ github.event_name == 'workflow_dispatch' && inputs.run_live_suite }}; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "Live Kafka alignment: will install k3s and run MetalLB / alignment suite steps."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Live cluster suite not requested (use Actions → workflow_dispatch → run_live_suite)."
+            echo "Static job above still validates alignment scripts on every run."
+          fi
+
       - name: Install kubectl
+        if: steps.live.outputs.enabled == 'true'
         uses: azure/setup-kubectl@v4
         with:
-          version: "v1.29.0"
+          version: "v1.31.0"
 
       - name: Install k3s
+        if: steps.live.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           curl -sfL https://get.k3s.io | sudo sh -s - --write-kubeconfig-mode 644
@@ -94,21 +122,23 @@ jobs:
           kubectl get nodes -o wide
 
       - name: MetalLB smoke (same as ephemeral-cluster)
+        if: steps.live.outputs.enabled == 'true'
         env:
           CI_MODE: "1"
         run: bash scripts/ci/ephemeral-k3s-converge.sh
 
       - name: Kafka alignment suite (fails if Kafka is deployed and misaligned)
+        if: steps.live.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           if kubectl get statefulset kafka -n off-campus-housing-tracker --request-timeout=15s >/dev/null 2>&1; then
             make kafka-alignment-suite
           else
-            echo "No statefulset/kafka in off-campus-housing-tracker — live suite skipped (deploy Kafka on this cluster to exercise)."
+            echo "No statefulset/kafka in off-campus-housing-tracker — alignment suite not exercised (expected on fresh k3s)."
           fi
 
       - name: Upload alignment artifacts
-        if: always()
+        if: always() && steps.live.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: kafka-alignment-report

--- a/.github/workflows/kafka-cluster-verify.yml
+++ b/.github/workflows/kafka-cluster-verify.yml
@@ -6,7 +6,15 @@ on:
   # Every PR runs (stable CI surface). Push to main/master stays path-filtered to save minutes.
   pull_request:
   push:
-    branches: [main, master, develop]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
     paths:
       - "infra/k8s/kafka-kraft-metallb/**"
       - "scripts/verify-kafka-*.sh"
@@ -17,10 +25,11 @@ on:
       - "scripts/check-kafka-config-drift.sh"
       - "Makefile"
       - ".github/workflows/kafka-cluster-verify.yml"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/kafka-dns-validate.yml
+++ b/.github/workflows/kafka-dns-validate.yml
@@ -3,7 +3,15 @@ name: kafka-dns-validate
 
 on:
   push:
-    branches: [main, master, develop]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
     paths:
       - "scripts/validate-kafka-dns.sh"
       - "scripts/preflight-kafka-k8s-rollout.sh"
@@ -12,12 +20,13 @@ on:
       - "infra/ops/**"
       - "infra/policies/kafka-replica-guard.yaml"
       - "monitoring/prometheus-rules/kafka-kraft-dns.yaml"
+      - ".github/workflows/**"
   # Every PR runs (same checks without guessing which paths changed).
   pull_request:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -27,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: azure/setup-kubectl@v4
         with:
-          version: "v1.30.2"
+          version: "v1.31.0"
       - name: Bash syntax (Kafka helper scripts)
         run: |
           bash -n scripts/validate-kafka-dns.sh

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -98,7 +98,7 @@ jobs:
         if: github.event.inputs.execution_mode == 'kubeconfig-secret'
         uses: azure/setup-kubectl@v4
         with:
-          version: "v1.29.0"
+          version: "v1.31.0"
 
       - name: Install OS deps (kubeconfig-secret mode)
         if: github.event.inputs.execution_mode == 'kubeconfig-secret'

--- a/.github/workflows/protocol-readiness.yml
+++ b/.github/workflows/protocol-readiness.yml
@@ -4,16 +4,25 @@ name: Protocol readiness gate
 
 on:
   push:
-    branches: [main, master]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
     paths:
       - "scripts/protocol/**"
       - "infra/k8s/base/config/strict-envelope.json"
       - ".github/workflows/protocol-readiness.yml"
-  # Every PR runs; push to main/master stays path-filtered above.
+      - ".github/workflows/**"
+  # Every PR runs; push uses path filters above (plus any workflow change).
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/protocol-validation.yml
+++ b/.github/workflows/protocol-validation.yml
@@ -4,7 +4,15 @@ name: Protocol validation (static + fixtures)
 
 on:
   push:
-    branches: [main, master]
+    branches:
+      - main
+      - master
+      - develop
+      - fix/**
+      - feat/**
+      - feature/**
+      - chore/**
+      - hotfix/**
     paths:
       - "scripts/protocol/**"
       - "scripts/transport/**"
@@ -28,12 +36,13 @@ on:
       - "webapp/playwright.global-setup.ts"
       - "webapp/package.json"
       - ".github/workflows/protocol-validation.yml"
-  # All PRs run this workflow (predictable check count). Push to main/master stays path-filtered above.
+      - ".github/workflows/**"
+  # All PRs run this workflow (predictable check count). Push uses path filters above (plus any workflow change).
   pull_request:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -566,11 +566,7 @@ dev-onboard-lite: ## CI-safe: bash -n scripts, kustomize kafka bundle, onboard s
 	  || { echo "kubectl kustomize failed (housing base):" >&2; kubectl kustomize "$(REPO_ROOT)/infra/k8s/base" >&2 | tail -80 >&2 || true; _kustomize_fail; }; \
 	kubectl kustomize "$(REPO_ROOT)/infra/k8s/overlays/dev" >/dev/null \
 	  || { echo "kubectl kustomize failed (housing dev overlay):" >&2; kubectl kustomize "$(REPO_ROOT)/infra/k8s/overlays/dev" >&2 | tail -80 >&2 || true; _kustomize_fail; }; \
-	echo "▶ kubectl apply --dry-run=client (schema/client validation, no cluster required)"; \
-	kubectl apply --dry-run=client -k "$(REPO_ROOT)/infra/k8s/base" -o name >/dev/null \
-	  || { echo "kubectl apply --dry-run=client failed (base)" >&2; _kustomize_fail; }; \
-	kubectl apply --dry-run=client -k "$(REPO_ROOT)/infra/k8s/overlays/dev" -o name >/dev/null \
-	  || { echo "kubectl apply --dry-run=client failed (dev overlay)" >&2; _kustomize_fail; }; \
+	echo "▶ (skip kubectl apply --dry-run=client: still hits apiserver for GVK/rest mapping; fails on GHA without cluster)"; \
 	echo "▶ static onboard wiring"; \
 	test -x "$(SCRIPTS)/dev-onboard-local.sh"; \
 	test -x "$(SCRIPTS)/apply-kafka-kraft-staged.sh"; \

--- a/Makefile
+++ b/Makefile
@@ -525,7 +525,7 @@ onboarding-edge: ## verify-preflight-edge-routing (MetalLB + hosts + TLS)
 	$(MAKE) verify-preflight-edge-routing
 
 # ROLE: DEV — deterministic local onboard (EKS: dev-onboard-eks). Wrapper: scripts/dev-onboard-local.sh (set -euo pipefail).
-dev-onboard: ## LOCAL: phased onboard + TLS/Kafka gates (alias-guard, quorum-stable, edge-readiness); EKS: verify-only
+dev-onboard: ## LOCAL: phased onboard + TLS/Kafka gates + kafka-health post-edge (SKIP_KAFKA_HEALTH_ON_ONBOARD=1 to skip); EKS: verify-only
 	@chmod +x $(SCRIPTS)/detect-k8s-environment.sh $(SCRIPTS)/dev-onboard-local.sh
 	@_och_env=$$(bash $(SCRIPTS)/detect-k8s-environment.sh 2>/dev/null || echo LOCAL); \
 	if [ "$$_och_env" = "EKS" ]; then \
@@ -579,6 +579,7 @@ dev-onboard-lite: ## CI-safe: bash -n scripts, kustomize kafka bundle, onboard s
 	grep -q 'kafka-quorum-stable' "$(SCRIPTS)/dev-onboard-local.sh"; \
 	grep -q 'service-tls-alias-guard' "$(SCRIPTS)/dev-onboard-local.sh"; \
 	grep -q 'edge-readiness-gate' "$(SCRIPTS)/dev-onboard-local.sh"; \
+	grep -q 'kafka-health' "$(SCRIPTS)/dev-onboard-local.sh"; \
 	echo "▶ bash -n scripts/ci (smoke / verify helpers)"; \
 	bash -n "$(SCRIPTS)/ci/smoke-api-gateway.sh"; \
 	bash -n "$(SCRIPTS)/ci/canary-pod-stability.sh"; \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 make images
 
 # 2. Full local stack (~20–28 min first time; see docs/DEV_ONBOARDING.md)
-RESTORE_BACKUP_DIR=latest make dev-onboard
+RESTORE_BACKUP_DIR=latest make dev-onboard   # restore newest Postgres backups; or: make dev-onboard (no restore)
 ```
 
 **Prereqs:** Colima (or k3s) + Docker, **pnpm** (see root `packageManager`), **kubectl** pointed at the cluster (`export KUBECONFIG="$HOME/.colima/default/kubeconfig"` or `make kubeconfig-colima`).

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,19 +1,127 @@
-fix(ci): Kafka alignment, CI gates, chaos/resilience, auth outbox
+fix(ci): Docker build reliability, branch triggers, and workflow path filters
 
-- Kafka ↔ MetalLB: drift checks (check-kafka-config-drift, kafka-runtime-sync, kafka-sync-metallb),
-  alignment test suite, golden-snapshot; preflight 6a2c9 on by default (skip:
-  PREFLIGHT_SKIP_KAFKA_ALIGNMENT_SUITE=1); metallb alignment exporter; kafka-ops CronJob + Dockerfile;
-  Prometheus rules (runtime drift, alignment tests, suite missing).
-- Make: kafka-health, kafka-alignment-suite, chaos-suite-kafka, golden-snapshot.
-- CI: kafka-alignment + ephemeral/kafka-cluster-verify path filters; nightly chaos; diagrams workflow
-  (generated repo-root diagrams/, docs/assets, architecture submission/book/design/lld, scripts/architecture
-  not part of this commit).
-- Auth: transactional outbox (publisher, metrics, tests, inspect/replay); Grafana/Prometheus outbox assets;
-  user-lifecycle consumers across services.
-- Infra: k8s :dev deploy pins, observability, proto/config, prisma migrations, bench_logs cleanup.
-- CI hardening: dev-onboard-lite proto-on-disk + kustomize + kubectl apply --dry-run=client; PlantUML no .puml → exit 0;
-  diagrams/uml/placeholder.puml; post-deploy-verify workflow (self-hosted or kubeconfig secret); hydrate-certs-for-ci
-  (POST_DEPLOY_CERTS_ARCHIVE_B64 or pull kafka-ssl-secret / dev-root-ca); smoke/k6/canary scripts + Makefile targets;
-  api-gateway GET /health; alignment suite post-destructive verify; matplotlib venv + golden CHAOS destructive alignment.
+-------------------------------------------------------------------------------
+HIGH-LEVEL OVERVIEW (for teammates — not CI experts)
+-------------------------------------------------------------------------------
+
+We tightened GitHub Actions so that:
+
+  • Docker image builds stop failing for a silly reason: the build often
+    succeeded, but uploading the build cache back to GitHub timed out. CI
+    treated that as a failure, so the whole pipeline looked red even when
+    the code was fine.
+
+  • Pushes to normal feature branches (e.g. fix/..., feat/...) actually run
+    the main CI and Docker workflows. Before, many workflows only listened
+    for pushes to main — so if you pushed a branch without opening a PR yet,
+    nothing ran and it looked like "CI is broken" or "nothing happened."
+
+  • Pull requests that only change files under .github/workflows/ still
+    run the gates that care about infra (dev-onboard-lite, ephemeral cluster,
+    Kafka alignment checks, etc.). Those jobs used to skip because their
+    path filters did not include workflow files.
+
+  • The messaging-service image installs OpenSSL in the runtime layer so
+    Prisma/client tooling that expects libssl is aligned with what we run
+    in production-style containers (warning was non-fatal in CI but good
+    to fix for real deploys).
+
+  • When you open or update a PR, GitHub may run both a "push" and a
+    "pull_request" workflow for the same branch. That can look like duplicate
+    check names in the UI; we keep them from cancelling each other so neither
+    run dies halfway through (which used to look like random failures or
+    "missing" jobs).
+
+  • CI installs a recent kubectl (1.31+) for kustomize so dev overlays with
+    multi-doc patches build the same as on your laptop (older kubectl made
+    make dev-onboard-lite fail in GitHub only).
+
+You do not need to memorize buildx or cache backends — the point is: CI
+should reflect real breakage, not flaky GitHub infrastructure.
+
+-------------------------------------------------------------------------------
+WHY THIS MATTERS FOR THE SYSTEM AS A WHOLE
+-------------------------------------------------------------------------------
+
+OCH is many services (HTTP + gRPC + Kafka + Postgres/Redis) with shared
+contracts (proto, TLS, Kafka topics). CI is the contract enforcement layer:
+
+  • If docker builds fail spuriously, downstream jobs (Kafka alignment,
+    integration tests that assume images or scripts passed, etc.) never run
+    or are skipped — hard to tell signal from noise.
+
+  • If feature-branch pushes do not trigger CI, regressions slip until a PR
+    is opened or merged; reviewers lose early feedback.
+
+  • Workflow-only changes must still run kustomize / script / Kafka static
+    checks when those files are touched, or we merge YAML mistakes that only
+    show up on main.
+
+So these changes are "infra hygiene" that keeps the safety net honest for
+everyone shipping services, not a refactor of application logic.
+
+-------------------------------------------------------------------------------
+WHAT CHANGED (technical summary — recent CI/CD hardening)
+-------------------------------------------------------------------------------
+
+Docker / GitHub Actions (buildx)
+  - och-docker-build: removed cache-to type=gha (keep cache-from) to avoid
+    DeadlineExceeded / i/o timeout posting to results-receiver.actions.
+    githubusercontent.com after a successful build.
+  - och-docker-build: workflow_dispatch for manual reruns from the Actions tab.
+  - messaging-service Dockerfile: install openssl in the runtime stage
+    (alongside existing curl/ca-certificates for grpc-health-probe).
+
+Branch triggers (push)
+  - Expanded push branches to include fix/**, feat/**, feature/**,
+    chore/**, hotfix/** (in addition to main, master, develop) for:
+    och-ci, och-docker-build, Kafka alignment, protocol-validation,
+    protocol-readiness, kafka-dns-validate, kafka-cluster-verify.
+
+Path filters
+  - Added .github/workflows/** where workflow-only PRs/pushes were skipped:
+    dev-onboard-lite, ephemeral-cluster, kafka-alignment, kafka-dns-validate
+    (push), kafka-cluster-verify (push), protocol-validation/readiness (push).
+  - Kafka alignment also runs when docker-build.yml or
+    services/messaging-service/Dockerfile changes (already in place).
+
+Concurrency (why PR checks looked "empty" or cancelled)
+  - Groups now include github.event_name (push vs pull_request). Before, both
+    events shared the same branch-only key, so cancel-in-progress killed the
+    sibling run mid-job — integration tests cancelled, aggregate gate red, and
+    the PR could show only one event's checks or a short list while jobs were
+    still queued behind integration-tests.
+  - dev-onboard-lite, Ephemeral k3s + MetalLB, Diagrams: added push with the
+    same path filters as pull_request (plus feature-branch list) so those
+    gates run on push when paths match, not only on PRs.
+
+Kustomize / kubectl in CI
+  - GitHub workflows that run kubectl kustomize (dev-onboard-lite, ephemeral,
+    kafka-dns-validate, post-deploy-verify, Kafka alignment live) use kubectl
+    v1.31.0+. v1.29’s bundled kustomize rejects multi-document strategic-merge
+    patches such as infra/k8s/overlays/dev/patches/e2e-high-cap-mode-env.yaml.
+  - dev-onboard-lite no longer runs kubectl apply --dry-run=client -k: even
+    “client” dry-run asks the apiserver for GVK/rest mapping; GHA runners have
+    no cluster, so it fails against localhost:8080. kubectl kustomize already
+    proves the overlay builds.
+
+Kafka alignment “live” job
+  - The live job always runs after static (no job-level if). k3s / MetalLB /
+    alignment suite steps run only for workflow_dispatch with run_live_suite;
+    otherwise the gate step exits 0 with a short message so checks are not
+    listed as Skipped.
+
+-------------------------------------------------------------------------------
+BROADER CONTEXT (earlier large fix/ci work on main — reference)
+-------------------------------------------------------------------------------
+
+The repo also includes deeper CI/Kafka/auth work (separate merges), including:
+Kafka ↔ MetalLB alignment tooling and preflight, Make targets (kafka-health,
+kafka-alignment-suite, chaos/golden paths), auth transactional outbox and
+user-lifecycle consumers across services, k8s dev pins and observability,
+post-deploy verify and cert hydration scripts, etc. That is the functional
+stack; the items above are specifically about CI reliability and triggers.
+
+-------------------------------------------------------------------------------
 
 Made with Tom.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,127 +1,27 @@
-fix(ci): Docker build reliability, branch triggers, and workflow path filters
+dev(onboard): default post-edge kafka-health; document images → onboard contract
 
--------------------------------------------------------------------------------
-HIGH-LEVEL OVERVIEW (for teammates — not CI experts)
--------------------------------------------------------------------------------
+Summary
+-------
+- Local `make dev-onboard` now ends with Phase 10: `make kafka-health` by default
+  (full verify-kafka-cluster, kafka-runtime-sync --check-only, safe alignment suite
+  and CSV/PNG under bench_logs/kafka-alignment-report/).
+- Opt out only when needed: SKIP_KAFKA_HEALTH_ON_ONBOARD=1 (default is to run Phase 10;
+  unset or 0 runs kafka-health).
+- Makefile dev-onboard help text and dev-onboard-lite static grep updated so CI
+  catches dropped wiring.
 
-We tightened GitHub Actions so that:
+Two-process contract (docs)
+---------------------------
+- make images — builds all default housing :dev images (see
+  scripts/lib/och-housing-docker-services-default.sh) via build-housing-images-k3s.sh
+  and loads into Colima when Colima is up; does not apply k8s or run Kafka gates.
+- make dev-onboard — full bring-up: TLS/certs, KRaft, preflight, kafka-tls-guard,
+  alias/quorum gates, deploy-dev, edge hosts + routing, then post-edge kafka-health
+  unless explicitly skipped.
 
-  • Docker image builds stop failing for a silly reason: the build often
-    succeeded, but uploading the build cache back to GitHub timed out. CI
-    treated that as a failure, so the whole pipeline looked red even when
-    the code was fine.
-
-  • Pushes to normal feature branches (e.g. fix/..., feat/...) actually run
-    the main CI and Docker workflows. Before, many workflows only listened
-    for pushes to main — so if you pushed a branch without opening a PR yet,
-    nothing ran and it looked like "CI is broken" or "nothing happened."
-
-  • Pull requests that only change files under .github/workflows/ still
-    run the gates that care about infra (dev-onboard-lite, ephemeral cluster,
-    Kafka alignment checks, etc.). Those jobs used to skip because their
-    path filters did not include workflow files.
-
-  • The messaging-service image installs OpenSSL in the runtime layer so
-    Prisma/client tooling that expects libssl is aligned with what we run
-    in production-style containers (warning was non-fatal in CI but good
-    to fix for real deploys).
-
-  • When you open or update a PR, GitHub may run both a "push" and a
-    "pull_request" workflow for the same branch. That can look like duplicate
-    check names in the UI; we keep them from cancelling each other so neither
-    run dies halfway through (which used to look like random failures or
-    "missing" jobs).
-
-  • CI installs a recent kubectl (1.31+) for kustomize so dev overlays with
-    multi-doc patches build the same as on your laptop (older kubectl made
-    make dev-onboard-lite fail in GitHub only).
-
-You do not need to memorize buildx or cache backends — the point is: CI
-should reflect real breakage, not flaky GitHub infrastructure.
-
--------------------------------------------------------------------------------
-WHY THIS MATTERS FOR THE SYSTEM AS A WHOLE
--------------------------------------------------------------------------------
-
-OCH is many services (HTTP + gRPC + Kafka + Postgres/Redis) with shared
-contracts (proto, TLS, Kafka topics). CI is the contract enforcement layer:
-
-  • If docker builds fail spuriously, downstream jobs (Kafka alignment,
-    integration tests that assume images or scripts passed, etc.) never run
-    or are skipped — hard to tell signal from noise.
-
-  • If feature-branch pushes do not trigger CI, regressions slip until a PR
-    is opened or merged; reviewers lose early feedback.
-
-  • Workflow-only changes must still run kustomize / script / Kafka static
-    checks when those files are touched, or we merge YAML mistakes that only
-    show up on main.
-
-So these changes are "infra hygiene" that keeps the safety net honest for
-everyone shipping services, not a refactor of application logic.
-
--------------------------------------------------------------------------------
-WHAT CHANGED (technical summary — recent CI/CD hardening)
--------------------------------------------------------------------------------
-
-Docker / GitHub Actions (buildx)
-  - och-docker-build: removed cache-to type=gha (keep cache-from) to avoid
-    DeadlineExceeded / i/o timeout posting to results-receiver.actions.
-    githubusercontent.com after a successful build.
-  - och-docker-build: workflow_dispatch for manual reruns from the Actions tab.
-  - messaging-service Dockerfile: install openssl in the runtime stage
-    (alongside existing curl/ca-certificates for grpc-health-probe).
-
-Branch triggers (push)
-  - Expanded push branches to include fix/**, feat/**, feature/**,
-    chore/**, hotfix/** (in addition to main, master, develop) for:
-    och-ci, och-docker-build, Kafka alignment, protocol-validation,
-    protocol-readiness, kafka-dns-validate, kafka-cluster-verify.
-
-Path filters
-  - Added .github/workflows/** where workflow-only PRs/pushes were skipped:
-    dev-onboard-lite, ephemeral-cluster, kafka-alignment, kafka-dns-validate
-    (push), kafka-cluster-verify (push), protocol-validation/readiness (push).
-  - Kafka alignment also runs when docker-build.yml or
-    services/messaging-service/Dockerfile changes (already in place).
-
-Concurrency (why PR checks looked "empty" or cancelled)
-  - Groups now include github.event_name (push vs pull_request). Before, both
-    events shared the same branch-only key, so cancel-in-progress killed the
-    sibling run mid-job — integration tests cancelled, aggregate gate red, and
-    the PR could show only one event's checks or a short list while jobs were
-    still queued behind integration-tests.
-  - dev-onboard-lite, Ephemeral k3s + MetalLB, Diagrams: added push with the
-    same path filters as pull_request (plus feature-branch list) so those
-    gates run on push when paths match, not only on PRs.
-
-Kustomize / kubectl in CI
-  - GitHub workflows that run kubectl kustomize (dev-onboard-lite, ephemeral,
-    kafka-dns-validate, post-deploy-verify, Kafka alignment live) use kubectl
-    v1.31.0+. v1.29’s bundled kustomize rejects multi-document strategic-merge
-    patches such as infra/k8s/overlays/dev/patches/e2e-high-cap-mode-env.yaml.
-  - dev-onboard-lite no longer runs kubectl apply --dry-run=client -k: even
-    “client” dry-run asks the apiserver for GVK/rest mapping; GHA runners have
-    no cluster, so it fails against localhost:8080. kubectl kustomize already
-    proves the overlay builds.
-
-Kafka alignment “live” job
-  - The live job always runs after static (no job-level if). k3s / MetalLB /
-    alignment suite steps run only for workflow_dispatch with run_live_suite;
-    otherwise the gate step exits 0 with a short message so checks are not
-    listed as Skipped.
-
--------------------------------------------------------------------------------
-BROADER CONTEXT (earlier large fix/ci work on main — reference)
--------------------------------------------------------------------------------
-
-The repo also includes deeper CI/Kafka/auth work (separate merges), including:
-Kafka ↔ MetalLB alignment tooling and preflight, Make targets (kafka-health,
-kafka-alignment-suite, chaos/golden paths), auth transactional outbox and
-user-lifecycle consumers across services, k8s dev pins and observability,
-post-deploy verify and cert hydration scripts, etc. That is the functional
-stack; the items above are specifically about CI reliability and triggers.
-
--------------------------------------------------------------------------------
+Docs
+----
+- docs/DEV_ONBOARDING.md — section 0) two-step contract; Phase 10 wording.
+- docs/ONBOARDING_READINESS_AUDIT.md — Phase 10 row + summary note.
 
 Made with Tom.

--- a/docs/DEV_ONBOARDING.md
+++ b/docs/DEV_ONBOARDING.md
@@ -2,7 +2,21 @@
 
 This doc answers **developer experience** questions after moving Kafka off Docker Compose to **three-broker KRaft in Kubernetes**, and documents the **one-command** path.
 
-## One command: full stack
+## Backend: use this order
+
+### 1) Clean build — images once
+
+**`make dev-onboard` does not build container images for you.** It assumes **:dev** images already exist in the Docker daemon that Colima/k3s uses.
+
+From the repo root, build (or rebuild after Dockerfile changes) and load into the cluster:
+
+```bash
+make images
+```
+
+(`make images` → `scripts/build-housing-images-k3s.sh`. Heavier refresh: `make images-all`.)
+
+### 2) Full local stack (~20–28 min first time)
 
 From the repo root (Colima recommended). **MetalLB pool:** leave **`METALLB_POOL` unset** in `make cluster` / `make up` — **`scripts/install-metallb-colima.sh`** and **`setup-new-colima-cluster.sh`** pick **`.240`–`.250`** on the Colima VM / node subnet automatically. Override only if you must.
 
@@ -12,6 +26,8 @@ export RESTORE_BACKUP_DIR=latest
 
 make dev-onboard
 ```
+
+Omit **`RESTORE_BACKUP_DIR`** if you want empty databases instead of restoring from **`backups/`**.
 
 **What `make dev-onboard` runs (high level):**
 
@@ -108,6 +124,7 @@ make onboarding-edge
 
 | Target | Purpose |
 |--------|---------|
+| `make images` | Build **:dev** service images and load into Colima/k3s (**run before** first `dev-onboard`; onboard does not build images). |
 | `make dev-onboard` | Full onboarding (see above). |
 | `make apply-kafka-kraft` | Apply KRaft manifests + wait for StatefulSet. |
 | `make onboarding-kafka-preflight` | Cleanup ops pods, DNS verify, topic preflight, bootstrap verify. |
@@ -121,9 +138,23 @@ make onboarding-edge
 
 ---
 
+## Frontend (Next.js webapp)
+
+From the **repo root** after the backend stack is up (gateway reachable; see **`webapp/README.md`**):
+
+```bash
+pnpm install   # once per clone / lockfile change
+pnpm --filter webapp dev     # daily work; hot reload at http://localhost:3000
+```
+
+When you need a **production** check (not every edit): `pnpm --filter webapp build` then `pnpm --filter webapp start`.
+
+---
+
 ## Related docs
 
 - `README.md` — build/run overview  
+- `webapp/README.md` — webapp env, E2E, k6  
 - `docs/MAKE_DEMO.md` — Colima, MetalLB pool, k3d  
 - `docs/ENGINEERING_DELIVERABLE_REPORT.md` §2.4.8 — MetalLB justification  
 - `docker-compose.yml` — Postgres / Redis / MinIO only (comments: Kafka in-cluster)

--- a/docs/DEV_ONBOARDING.md
+++ b/docs/DEV_ONBOARDING.md
@@ -21,13 +21,14 @@ make images
 From the repo root (Colima recommended). **MetalLB pool:** leave **`METALLB_POOL` unset** in `make cluster` / `make up` — **`scripts/install-metallb-colima.sh`** and **`setup-new-colima-cluster.sh`** pick **`.240`–`.250`** on the Colima VM / node subnet automatically. Override only if you must.
 
 ```bash
-# Optional: restore all eight Postgres DBs from the newest backup snapshot
-export RESTORE_BACKUP_DIR=latest
+# Restore all eight Postgres DBs from the newest snapshot under backups/ (optional)
+RESTORE_BACKUP_DIR=latest make dev-onboard
 
+# Empty databases / SQL bootstrap path (no backup restore in Phase 0):
 make dev-onboard
 ```
 
-Omit **`RESTORE_BACKUP_DIR`** if you want empty databases instead of restoring from **`backups/`**.
+**`RESTORE_BACKUP_DIR`:** only set **`=latest`** when you want a dump restore. If you omit it, **`make dev-onboard`** passes an empty value and Phase 0 restore is skipped (matches `scripts/dev-onboard-local.sh`).
 
 **What `make dev-onboard` runs (high level):**
 
@@ -40,12 +41,13 @@ Omit **`RESTORE_BACKUP_DIR`** if you want empty databases instead of restoring f
    - Then **metallb-fix**, **`hosts-sanity` / `ensure-edge-hosts`** (default **`HOSTS_AUTO=1`**: discovers Caddy/ingress **LoadBalancer IP** via **kubectl** and appends **`/etc/hosts`** with **sudo** when missing — no IP yet before **deploy-dev** is OK), **preflight-gate**, etc.
 2. **`make kafka-onboarding-reset`** — Deletes **kafka-0/1/2-external** LoadBalancers and headless **kafka** Service (and related EndpointSlices) so the next apply gets **fresh MetalLB** assignments and clean DNS (no-op on first run if resources are absent).
 3. **`make apply-kafka-kraft`** — **`kubectl apply -k infra/k8s/kafka-kraft-metallb/`** and **wait for StatefulSet rollout** (requires **`kafka-ssl-secret`** from **`make up`**).
-4. **`make onboarding-kafka-preflight`** — **cleanup** ops Job pods, **verify-kafka-dns**, **preflight-kafka-k8s**, **verify-kafka-bootstrap**.
-5. **`make verify-kafka-cluster`** — Full ritual including **meta.properties** **cluster.id** / **node.id**, TLS SANs, **advertised.listeners**, quorum, broker API (fails before **`deploy-dev`** if Kafka is unhealthy).
-6. **`SKIP_STRICT_ENVELOPE=1`** **`deploy-dev`** — kustomize **overlays/dev**, Caddy rollout, workloads.
-7. **`make wait-for-caddy-ip`** — Polls until **caddy-h3** has an **EXTERNAL-IP** (~120s max) so **`ensure-edge-hosts`** does not race MetalLB.
-8. **`make ensure-edge-hosts`** with **`EDGE_HOSTS_STRICT=1`** — Rewrites **`/etc/hosts`** for **off-campus-housing.test** (replaces **stale** lines if the LB IP changed; **sudo**).
-9. **`make onboarding-edge`** — **verify-preflight-edge-routing** (ingress parity, DNS → LB, HTTPS — not **ping**).
+4. **`make onboarding-kafka-preflight`** — **cleanup** ops Job pods, **verify-kafka-dns**, **preflight-kafka-k8s** (ensures event topics), **verify-kafka-bootstrap**.
+5. **`make kafka-tls-guard`** — TLS/JKS checks and **full `verify-kafka-cluster`** ritual (meta / SANs / listeners / quorum / broker API) — fails before app deploy if Kafka is unhealthy.
+6. **Secrets + alias + quorum** — **`ensure-housing-cluster-secrets`**, **`service-tls-alias-guard`**, **`kafka-quorum-stable`**, deferred TLS rollouts.
+7. **`SKIP_STRICT_ENVELOPE=1`** **`deploy-dev`** — kustomize **overlays/dev**, Caddy rollout, workloads.
+8. **`make wait-for-caddy-ip`** — Polls until **caddy-h3** has an **EXTERNAL-IP** (~120s max) so **`ensure-edge-hosts`** does not race MetalLB.
+9. **`make ensure-edge-hosts`** with **`EDGE_HOSTS_STRICT=1`** — Rewrites **`/etc/hosts`** for **off-campus-housing.test** (replaces **stale** lines if the LB IP changed; **sudo**).
+10. **`make onboarding-edge`** — **verify-preflight-edge-routing** (ingress parity, DNS → LB, HTTPS — not **ping**).
 
 **`/etc/hosts`:** Handled automatically (**`HOSTS_AUTO=1`**); stale IPs are **replaced**, not duplicated. **`HOSTS_AUTO=0`** for hints only; **`EXTERNAL_IP=`** to pin. **`OCH_EDGE_HOSTNAME`** overrides the hostname.
 

--- a/docs/DEV_ONBOARDING.md
+++ b/docs/DEV_ONBOARDING.md
@@ -4,6 +4,14 @@ This doc answers **developer experience** questions after moving Kafka off Docke
 
 ## Backend: use this order
 
+### 0) Two-step contract (build, then bring-up + gates)
+
+1. **`make images`** — Builds **every default housing service image** at **`:dev`** (`auth-service`, `listings-service`, `booking-service`, `messaging-service`, `trust-service`, `analytics-service`, `media-service`, `notification-service`, `api-gateway`, `transport-watchdog`; see `scripts/lib/och-housing-docker-services-default.sh`) via **`scripts/build-housing-images-k3s.sh`**, and **loads them into Colima** when Colima is running. Subset builds: `SERVICES="api-gateway" make images`. This step does **not** apply Kubernetes manifests or run Kafka verification.
+
+2. **`make dev-onboard`** — Brings the **full local stack** up in order: cluster/MetalLB, **TLS / dev-root / service TLS / Kafka JKS**, host Postgres/Redis/MinIO, **KRaft apply**, DNS/topics preflight, **`kafka-tls-guard`** (includes full **`verify-kafka-cluster`**), **service-tls alias + quorum gates**, app **`deploy-dev`**, edge **`/etc/hosts`** + routing checks, then **by default** **`make kafka-health`** (full **`verify-kafka-cluster`** again, **`kafka-runtime-sync.sh --check-only`**, and the **safe** alignment suite with reports under **`bench_logs/kafka-alignment-report/`**). **Phase 10 is not skipped unless you set `SKIP_KAFKA_HEALTH_ON_ONBOARD=1`.**
+
+Together, that is the supported path for “all images built” plus “all routine safety checks,” without running the optional **destructive** seven-test alignment or chaos suites (those stay manual; see step list below).
+
 ### 1) Clean build — images once
 
 **`make dev-onboard` does not build container images for you.** It assumes **:dev** images already exist in the Docker daemon that Colima/k3s uses.
@@ -48,6 +56,9 @@ make dev-onboard
 8. **`make wait-for-caddy-ip`** — Polls until **caddy-h3** has an **EXTERNAL-IP** (~120s max) so **`ensure-edge-hosts`** does not race MetalLB.
 9. **`make ensure-edge-hosts`** with **`EDGE_HOSTS_STRICT=1`** — Rewrites **`/etc/hosts`** for **off-campus-housing.test** (replaces **stale** lines if the LB IP changed; **sudo**).
 10. **`make onboarding-edge`** — **verify-preflight-edge-routing** (ingress parity, DNS → LB, HTTPS — not **ping**).
+11. **`make kafka-health`** — Runs again after edge is up: **full `verify-kafka-cluster`** (advertised.listeners vs MetalLB, CA fingerprint / broker chain, quorum, leadership churn, broker API, etc.), **`kafka-runtime-sync.sh --check-only`**, then the **safe** alignment suite (tests 2–4 and 6–7 skipped; baseline + TLS drift detection), writing **CSV/PNG** under **`bench_logs/kafka-alignment-report/`**. Skip with **`SKIP_KAFKA_HEALTH_ON_ONBOARD=1 make dev-onboard`** if you need a faster finish and accept less post-edge verification.
+
+**Optional destructive certification** (mutating; long-running, tens of minutes): **`KAFKA_ALIGNMENT_TEST_MODE=1 make kafka-alignment-suite`** for the full seven-test alignment matrix, or **`make kafka-health-chaos-cert`** / **`GOLDEN_SNAPSHOT_CHAOS=1 make golden-snapshot`** when you intend chaos (may require **`CHAOS_CONFIRM=1`**). These are **not** part of default **`make dev-onboard`**.
 
 **`/etc/hosts`:** Handled automatically (**`HOSTS_AUTO=1`**); stale IPs are **replaced**, not duplicated. **`HOSTS_AUTO=0`** for hints only; **`EXTERNAL_IP=`** to pin. **`OCH_EDGE_HOSTNAME`** overrides the hostname.
 
@@ -70,7 +81,8 @@ make dev-onboard
 9. **App deploy** — **`deploy-dev`**.  
 10. **Edge IP** — **`wait-for-caddy-ip`**.  
 11. **`/etc/hosts`** — **`ensure-edge-hosts`** (STRICT: resolver must match Caddy LB).  
-12. **Edge gates** — **`verify-preflight-edge-routing`** (HTTPS / QUIC paths, not ping).
+12. **Edge gates** — **`verify-preflight-edge-routing`** (HTTPS / QUIC paths, not ping).  
+13. **Post-edge Kafka health** — **`kafka-health`** (full cluster verify + runtime-sync check + safe alignment reports).
 
 **EKS:** **`make dev-onboard-eks`** runs verify-only (no MetalLB pool, hosts, or Kafka reset). Use ACM / cert-manager and real DNS.
 
@@ -135,6 +147,8 @@ make onboarding-edge
 | `make wait-for-caddy-ip` | Wait for **caddy-h3** MetalLB IP. |
 | `make ensure-edge-hosts` | **`/etc/hosts`** for edge hostname → LB IP (strict: **`EDGE_HOSTS_STRICT=1`**). |
 | `make onboarding-edge` | Edge routing / HTTPS verify (curl — not ICMP). |
+| `make kafka-health` | Full **`verify-kafka-cluster`** + **`kafka-runtime-sync --check-only`** + safe **`kafka-alignment-suite`** (reports under **`bench_logs/kafka-alignment-report/`**). Runs at end of **`make dev-onboard`** unless **`SKIP_KAFKA_HEALTH_ON_ONBOARD=1`**. |
+| `make kafka-health-chaos-cert` | **`kafka-health`** then destructive alignment + chaos (needs confirm); not part of default onboard. |
 | `make up` | Cluster + TLS + host infra + bootstrap **without** KRaft apply and **without** `deploy-dev`. |
 | `make cleanup-kafka-ops-pods` | Remove finished kafka-quorum / DNS remediator Job pods. |
 

--- a/docs/ONBOARDING_READINESS_AUDIT.md
+++ b/docs/ONBOARDING_READINESS_AUDIT.md
@@ -1,0 +1,131 @@
+# Onboarding readiness audit (repo facts)
+
+Structured check: **does a clean clone + docs match what the scripts actually do?**  
+Last reviewed: generated from Makefile + `scripts/dev-onboard-local.sh` + related paths.
+
+## Summary
+
+| Area | Status | Notes |
+|------|--------|--------|
+| Backend order (`make images` → `make dev-onboard`) | **PASS** | `dev-onboard` never calls `make images`; missing images → pull/mount failures on deploy. |
+| Kafka hardened gates in local onboard | **PASS** | Phases include DNS, topic preflight, TLS guard (includes `verify-kafka-cluster`), quorum-stable, edge readiness, mounts check. |
+| DB bootstrap / restore | **PASS with nuance** | Restore vs SQL bootstrap depends on `RESTORE_BACKUP_DIR` (see below). |
+| Frontend (`pnpm --filter webapp`) | **PASS** | Next.js; not Vite — no `VITE_*`. |
+| Docs vs script default for restore | **FIXED** | Script used `export RESTORE_BACKUP_DIR="${RESTORE_BACKUP_DIR:-latest}"`, so an empty value from **`make dev-onboard`** still forced **`latest`**. Default export **removed** — empty **`RESTORE_BACKUP_DIR`** skips Phase-0 restore; set **`=latest`** explicitly when you want dumps. |
+
+**Risk level:** **Low–Moderate** (Colima/MetalLB/Docker prerequisites; `deploy-dev.sh` uses `|| true` on some applies — see footguns).
+
+---
+
+## 1. Backend onboarding
+
+### Required commands (documented)
+
+1. `make images` — builds `HOUSING_DOCKER_SERVICES_DEFAULT` (`auth-service`, `listings-service`, … `api-gateway`, `transport-watchdog`) as `:dev`, loads into Colima when Colima is up.
+2. `RESTORE_BACKUP_DIR=latest make dev-onboard` — when you want the newest `backups/` restore for Postgres.  
+   `make dev-onboard` alone — **no** Phase-0 restore (empty DB / SQL bootstrap path).
+
+### Does `dev-onboard` depend on images existing?
+
+**YES.** It applies Deployments expecting images such as `auth-service:dev` (imagePullPolicy typically Never/local). **No pre-flight `docker image inspect`** — failure surfaces as pod events (`ErrImageNeverPull`, `ImagePullBackOff`).
+
+### Does it fail if images missing?
+
+**Eventually YES** (rollout/smoke/health), but **not** at a single dedicated “images missing” gate. README already warns about `ImagePullBackOff`.
+
+### Kafka: topics, TLS, checks — skipped?
+
+**NO** for the scripted local path (`scripts/dev-onboard-local.sh`):
+
+| Phase | What runs |
+|-------|-----------|
+| 2 | `kafka-onboarding-reset` |
+| 3 | `apply-kafka-kraft` |
+| 4 | `onboarding-kafka-preflight` → cleanup jobs, `verify-kafka-dns`, `preflight-kafka-k8s` (**creates event topics** via `create-kafka-event-topics-k8s.sh`), `verify-kafka-bootstrap` |
+| 5 | `kafka-tls-guard` → includes **full `verify-kafka-cluster`** (per Makefile target comment + script) |
+| 5a–5a2 | cluster secrets, `service-tls-alias-guard`, `kafka-quorum-stable` |
+| 5b | deferred TLS rollouts |
+| 6 | `deploy-dev.sh` (strict envelope skipped with `SKIP_STRICT_ENVELOPE=1`) |
+| 6b | optional client mount check via `verify-kafka-cluster.sh` |
+| 7–9 | Caddy IP, `edge-readiness-gate`, `ensure-edge-hosts`, `onboarding-edge` |
+
+Script uses **`set -euo pipefail`** — a failing `make` sub-step aborts onboard.
+
+### Prisma / DB migrations
+
+- **Host Postgres:** `bootstrap-all-dbs.sh` applies **ordered SQL** under `infra/db/` (not Prisma CLI in that script). Auth notes Prisma/restore in comments.
+- **In-cluster:** schema lifecycle depends on service images + env; onboard does **not** run `prisma migrate deploy` as a single explicit gate in `dev-onboard-local.sh`.
+- **Restore path:** Phase 0 uses `bring-up-external-infra.sh` with `SKIP_BOOTSTRAP=1` when restoring from dumps.
+
+### Certs / TLS
+
+Generated and wired through **`make up`** chain (`tls-first-time`, `generate-canonical-dev-tls.sh`, Kafka JKS refresh after LB, etc.). Not skipped in the strict local script.
+
+### Ports (representative)
+
+- **api-gateway (internal rewrite target):** `4020` (see `webapp/next.config.mjs` `API_GATEWAY_INTERNAL`).
+- **Postgres (compose):** 5441–5448 (documented in bootstrap scripts).
+- **Webapp dev:** `3000`.
+
+---
+
+## 2. Frontend onboarding
+
+| Check | Result |
+|-------|--------|
+| Commands valid | **YES** — `pnpm --filter webapp` matches workspace package `name: webapp`. |
+| Requires backend | **Partially** — UI loads; **auth/API flows need gateway** (default rewrites to `http://127.0.0.1:4020`). |
+| `VITE_API_URL` | **N/A** — Next.js app; use `NEXT_PUBLIC_API_BASE` only if bypassing rewrites. |
+| `.env` required | **NO** for default local (rewrites to gateway). |
+| Proxy | **YES** — `next.config.mjs` rewrites `/api/*` → `API_GATEWAY_INTERNAL`. |
+
+---
+
+## 3. Footguns (fresh machine)
+
+| Item | Severity |
+|------|----------|
+| **Docker + Colima/k3s** | **Required** — no cluster → `kubectl` steps fail. |
+| **`kubectl` context** | **Required** — `deploy-dev.sh` exits if no current context. |
+| **MetalLB / LoadBalancer** | **Required** for edge path (Caddy IP, hosts). |
+| **macOS `sudo` for `/etc/hosts`** | **Common** — `HOSTS_AUTO=1` appends/updates hosts. |
+| **Docker login** | **Not required** for local `:dev` images (no registry push in `make images`). |
+| **First-run time** | **~20–30+ min** (cluster, TLS, Kafka quorum, rollouts) — docs ballpark is reasonable. |
+| **`deploy-dev.sh` `kubectl apply ... \|\| true`** | **Moderate** — can hide apply failures; onboard still may fail later on rollouts/smoke. |
+
+---
+
+## 4. Suggested improvements (optional)
+
+1. **Pre-flight images:** optional `make` target or start of `dev-onboard-local.sh`: check one `:dev` image exists → clear message “run `make images`”.
+2. **`deploy-dev.sh`:** reduce `|| true` on kustomize apply for stricter fail-fast (trade-off: flaky CRD ordering).
+3. **Single `docker info` / `kubectl version --client` check** at start of onboard (user suggestion) — improves error messages.
+
+---
+
+## 5. PASS/FAIL checklist
+
+- **Images before onboard documented:** PASS  
+- **Kafka gates not skipped on local onboard:** PASS  
+- **Topics created in preflight:** PASS  
+- **TLS + quorum gates present:** PASS  
+- **Frontend commands + API wiring:** PASS  
+- **Restore default vs docs:** **FIXED** in `dev-onboard-local.sh` (removed forced default to `latest`).
+
+---
+
+## 6. What teammates should run (canonical)
+
+```bash
+# Backend (repo root)
+make images
+RESTORE_BACKUP_DIR=latest make dev-onboard   # or: RESTORE_BACKUP_DIR= make dev-onboard
+
+# Frontend (repo root)
+pnpm install
+pnpm --filter webapp dev
+# Production check (optional):
+# pnpm --filter webapp build && pnpm --filter webapp start
+```
+
+Primary narrative doc: **`docs/DEV_ONBOARDING.md`** and **`webapp/README.md`**.

--- a/docs/ONBOARDING_READINESS_AUDIT.md
+++ b/docs/ONBOARDING_READINESS_AUDIT.md
@@ -8,7 +8,7 @@ Last reviewed: generated from Makefile + `scripts/dev-onboard-local.sh` + relate
 | Area | Status | Notes |
 |------|--------|--------|
 | Backend order (`make images` → `make dev-onboard`) | **PASS** | `dev-onboard` never calls `make images`; missing images → pull/mount failures on deploy. |
-| Kafka hardened gates in local onboard | **PASS** | Phases include DNS, topic preflight, TLS guard (includes `verify-kafka-cluster`), quorum-stable, edge readiness, mounts check. |
+| Kafka hardened gates in local onboard | **PASS** | Phases include DNS, topic preflight, TLS guard (includes `verify-kafka-cluster`), quorum-stable, edge readiness, mounts check, and post-edge **`make kafka-health`** (runtime-sync check + safe alignment reports; skippable). |
 | DB bootstrap / restore | **PASS with nuance** | Restore vs SQL bootstrap depends on `RESTORE_BACKUP_DIR` (see below). |
 | Frontend (`pnpm --filter webapp`) | **PASS** | Next.js; not Vite — no `VITE_*`. |
 | Docs vs script default for restore | **FIXED** | Script used `export RESTORE_BACKUP_DIR="${RESTORE_BACKUP_DIR:-latest}"`, so an empty value from **`make dev-onboard`** still forced **`latest`**. Default export **removed** — empty **`RESTORE_BACKUP_DIR`** skips Phase-0 restore; set **`=latest`** explicitly when you want dumps. |
@@ -48,6 +48,7 @@ Last reviewed: generated from Makefile + `scripts/dev-onboard-local.sh` + relate
 | 6 | `deploy-dev.sh` (strict envelope skipped with `SKIP_STRICT_ENVELOPE=1`) |
 | 6b | optional client mount check via `verify-kafka-cluster.sh` |
 | 7–9 | Caddy IP, `edge-readiness-gate`, `ensure-edge-hosts`, `onboarding-edge` |
+| 10 | `make kafka-health` — post-edge full `verify-kafka-cluster`, `kafka-runtime-sync --check-only`, safe alignment suite (CSV/PNG). Skipped when **`SKIP_KAFKA_HEALTH_ON_ONBOARD=1`**. |
 
 Script uses **`set -euo pipefail`** — a failing `make` sub-step aborts onboard.
 

--- a/scripts/dev-onboard-local.sh
+++ b/scripts/dev-onboard-local.sh
@@ -22,8 +22,10 @@ else
   echo "⚠️  kubectl not in PATH"
 fi
 
-# Empty RESTORE_BACKUP_DIR = skip Phase-0 dump restore and allow infra-cluster SQL bootstrap.
-export RESTORE_BACKUP_DIR="${RESTORE_BACKUP_DIR:-latest}"
+# RESTORE_BACKUP_DIR is passed from the Makefile (empty if unset in the calling environment).
+# - Non-empty (e.g. latest): Phase 0 runs bring-up-external-infra with restore from backups/.
+# - Empty: skip Phase-0 restore; infra-cluster / SQL bootstrap path (see docs).
+# Do not default to "latest" here — Make always passes the variable, so empty must mean "no restore".
 
 # Reissue must not rollout app Deployments until Kafka TLS is rolled + verified (Phase 5).
 export RESTART_SERVICES_AFTER_TLS=0

--- a/scripts/dev-onboard-local.sh
+++ b/scripts/dev-onboard-local.sh
@@ -6,6 +6,7 @@
 #        Phase 5 kafka-tls-guard + 5a ensure-housing-cluster-secrets + 5a1 service-tls-alias-guard.
 #   Kafka: Phase 5a2 kafka-quorum-stable (no QuorumController "leader is (none)" in window).
 #   Edge: Phase 5b deferred rollouts; Phase 7b edge-readiness-gate (MetalLB + Caddy + gateway /healthz + /readyz).
+#   Post-edge: Phase 10 make kafka-health (verify-kafka-cluster + runtime-sync check + safe alignment reports); SKIP_KAFKA_HEALTH_ON_ONBOARD=1 skips.
 # Destructive full reset (Kafka wipe + reissue chain): make dev-onboard-hardened-reset (not this script).
 set -euo pipefail
 
@@ -124,6 +125,17 @@ make ensure-edge-hosts
 
 echo "▶ Phase 9: Edge routing + HTTPS"
 make onboarding-edge
+
+# Post-edge Kafka cert: full verify-kafka-cluster + kafka-runtime-sync --check-only + safe alignment suite
+# (CSV/PNG under bench_logs/kafka-alignment-report/). Destructive 7-test suite: KAFKA_ALIGNMENT_TEST_MODE=1 make kafka-alignment-suite
+# or make kafka-health-chaos-cert — not run here by default.
+# Default: run kafka-health. Only SKIP_KAFKA_HEALTH_ON_ONBOARD=1 opts out (faster, less post-edge verification).
+if [[ "${SKIP_KAFKA_HEALTH_ON_ONBOARD:-0}" == "1" ]]; then
+  echo "▶ Phase 10: skipped (SKIP_KAFKA_HEALTH_ON_ONBOARD=1 — default is to run make kafka-health)"
+else
+  echo "▶ Phase 10: Kafka health + runtime-sync check + safe alignment suite (make kafka-health; default)"
+  make kafka-health
+fi
 
 _DEV_ONBOARD_T1="$(date +%s)"
 _DEV_ONBOARD_SEC=$((_DEV_ONBOARD_T1 - _DEV_ONBOARD_T0))

--- a/services/messaging-service/Dockerfile
+++ b/services/messaging-service/Dockerfile
@@ -34,7 +34,7 @@ ENV NODE_ENV=production
 
 # grpc-health-probe for strict TLS/mTLS health checks (K8s exec probes)
 ARG GRPC_HEALTH_PROBE_VERSION=v0.4.24
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates openssl && \
   ARCH=$(dpkg --print-architecture) && \
   case "$ARCH" in amd64) BINARY_ARCH=amd64 ;; arm64) BINARY_ARCH=arm64 ;; *) BINARY_ARCH=amd64 ;; esac && \
   curl -Lf -o /usr/local/bin/grpc-health-probe \

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -12,9 +12,9 @@ Bring up the platform **before** the webapp. From the **repo root**, respect thi
    ```
 2. **Full local stack** (~20–28 min first time):
    ```bash
-   RESTORE_BACKUP_DIR=latest make dev-onboard
+   RESTORE_BACKUP_DIR=latest make dev-onboard   # optional: restore from backups/
+   make dev-onboard                             # or: no Phase-0 restore (empty / SQL bootstrap path)
    ```
-   Use `RESTORE_BACKUP_DIR=latest` only if you want the newest Postgres backups restored; omit for empty DBs.
 
 You need **api-gateway** (and backing services) reachable — typically **`https://off-campus-housing.test`** via ingress or, for quick UI work, same-origin rewrites to **`http://127.0.0.1:4020`** (see below).
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -2,10 +2,33 @@
 
 Demo UI for **JWT auth** (via `api-gateway` → auth-service), **search history**, and **watchlist** (booking-service HTTP routes proxied under `/api/booking/*`).
 
-## Local development
+## Prerequisites (backend)
 
-1. Start **Postgres bookings** + **api-gateway**, **auth-service**, **booking-service** (e.g. k3s/Colima stack or port-forward gateway to `127.0.0.1:4020`).
-2. From repo root:
+Bring up the platform **before** the webapp. From the **repo root**, respect this order (details: **`docs/DEV_ONBOARDING.md`**):
+
+1. **Images once** — `make dev-onboard` does **not** build images for you:
+   ```bash
+   make images
+   ```
+2. **Full local stack** (~20–28 min first time):
+   ```bash
+   RESTORE_BACKUP_DIR=latest make dev-onboard
+   ```
+   Use `RESTORE_BACKUP_DIR=latest` only if you want the newest Postgres backups restored; omit for empty DBs.
+
+You need **api-gateway** (and backing services) reachable — typically **`https://off-campus-housing.test`** via ingress or, for quick UI work, same-origin rewrites to **`http://127.0.0.1:4020`** (see below).
+
+## Frontend — from repo root
+
+Install workspace deps once (from repo root):
+
+```bash
+pnpm install
+```
+
+### Day-to-day (when you change frontend code)
+
+Use the **dev** server — it hot-reloads; you do **not** need `build` / `start` on every save:
 
 ```bash
 pnpm --filter webapp dev
@@ -13,17 +36,28 @@ pnpm --filter webapp dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
-### API base URL
+### Production-like run (when to use `build` + `start`)
 
-- **Default (recommended for local):** leave `NEXT_PUBLIC_API_BASE` unset. The app calls same-origin `/api/...`; `next.config.mjs` **rewrites** those to `API_GATEWAY_INTERNAL` (default `http://127.0.0.1:4020`), avoiding CORS during dev.
-- **Edge / TLS:** set `NEXT_PUBLIC_API_BASE=https://off-campus-housing.test` and ensure your browser trusts the cert (or use curl with `-k` only for debugging).
-
-## Build
+Run these when you want to verify the **production** bundle (same as `next build` + `next start`), for example after **dependency upgrades**, **`next.config`** changes, or before you trust a release — not required on every small UI edit:
 
 ```bash
 pnpm --filter webapp build
 pnpm --filter webapp start
 ```
+
+(`build` then `start` in that order; both from repo root.)
+
+## Local development (details)
+
+1. Backend stack running (see **Prerequisites**).
+2. **`pnpm --filter webapp dev`** from repo root for normal work.
+
+Open [http://localhost:3000](http://localhost:3000).
+
+### API base URL
+
+- **Default (recommended for local):** leave `NEXT_PUBLIC_API_BASE` unset. The app calls same-origin `/api/...`; `next.config.mjs` **rewrites** those to `API_GATEWAY_INTERNAL` (default `http://127.0.0.1:4020`), avoiding CORS during dev.
+- **Edge / TLS:** set `NEXT_PUBLIC_API_BASE=https://off-campus-housing.test` and ensure your browser trusts the cert (or use curl with `-k` only for debugging).
 
 ## E2E (Playwright)
 


### PR DESCRIPTION
This PR upgrades the platform’s reliability, CI enforcement, and observability.

It introduces:
	•	Kafka ↔ MetalLB alignment detection + auto-remediation
	•	Auth transactional outbox + cross-service lifecycle consumers
	•	Stronger CI gates (build, infra, Kafka health, smoke)
	•	Internal observability dashboards + alerting hooks

⸻

What changed

Kafka / Platform Reliability
	•	Detects and prevents Kafka drift (LB ↔ advertised.listeners ↔ TLS SAN)
	•	Adds:
	•	kafka-runtime-sync (drift detection + fix)
	•	kafka-alignment-suite (test coverage)
	•	Prometheus metrics + alerts
	•	Preflight now enforces Kafka alignment by default

Prevents silent misconfig after restarts or IP changes

⸻

CI / CD Hardening
	•	Parallel Docker builds (faster + stable)
	•	Registry-based cache (no flaky GHA cache)
	•	New CI stages:
	•	infra validation (kustomize)
	•	Kafka health check
	•	post-deploy smoke (/health)
	•	Fixed diagram job (no failure on empty dirs)

CI now blocks bad infra before merge

⸻

 Auth + Data Consistency
	•	Added transactional outbox pattern
	•	DELETE /account:
	•	writes DB + outbox atomically
	•	publishes asynchronously via worker
	•	Introduced idempotent Kafka consumers across services

Guarantees no lost events + safe retries

⸻

 Observability + Resilience
	•	Grafana dashboards:
	•	cluster health
	•	Kafka health
	•	outbox + lifecycle
	•	services + latency
	•	chaos / SLO
	•	TLS expiry
	•	Prometheus alerts:
	•	Kafka drift
	•	alignment failures
	•	outbox backlog
	•	Local alert handler (webhook → script)

System is now observable + self-healing-ready

⸻

 Testing
	•	Kafka alignment suite (safe + destructive modes)
	•	Account deletion E2E scaffold
	•	Trust service HTTP integration tests
	•	CI acts as infra test (Kafka + smoke + k6 hooks)

⸻
 How to verify

make kafka-health
make kafka-alignment-suite
make dev-onboard-lite

Optional:

ACCOUNT_DELETION_E2E=1 pnpm run test:account-deletion-e2e


⸻

 Risks / Notes
	•	Kafka TLS regeneration requires local CA (by design)
	•	Destructive alignment tests are disabled by default
	•	Prisma migrations may require baseline on existing DBs

⸻

 Review focus

Please prioritize:
	•	scripts/tests/kafka-alignment-suite.sh
	•	scripts/kafka-runtime-sync.sh
	•	Makefile (kafka-health, CI targets)
	•	services/auth-service (outbox + DELETE /account)
	•	.github/workflows/*

Most other changes are generated files or manifests.

⸻

 Why this matters

Before:
	•	Kafka drift could silently break connectivity
	•	Event publishing could fail after DB commit
	•	CI lacked infra-level validation

After:
	•	Kafka alignment is enforced + tested
	•	Event pipeline is reliable + replayable
	•	CI acts as a real safety gate

⸻

 Outcome

This moves the system toward:

reliable, observable, and failure-resilient infrastructure
:::
