### PR TITLE
Fixing onboard

### DIFF
--- a/BOOKING_SERVICE_EXPANSION_NO_DB.md
+++ b/BOOKING_SERVICE_EXPANSION_NO_DB.md
@@ -1,0 +1,51 @@
+# Booking service expansion ideas (no database schema changes)
+
+Ways to grow **booking-service** behavior using **API design**, **composition**, **caching**, and **events**—without new migrations or tables.
+
+## 1. Read-model aggregation (gateway or BFF)
+
+- Add **gateway routes** that join **existing** booking responses with **listings-service** (or **trust-service**) data already exposed over gRPC/HTTP.
+- Keeps booking DB bounded; latency trades for fewer round-trips from the webapp.
+
+## 2. Redis / in-memory overlays (ephemeral state)
+
+- **Soft holds**: short-TTL keys (`booking:hold:{listingId}:{userId}`) for “someone is checking out” UX—no Postgres row until confirm.
+- **Idempotency**: store `Idempotency-Key → booking_id` in Redis to make **create** safe under retries (TTL aligned with client timeout).
+- **Rate limits**: token bucket per user/listing using existing Redis patterns elsewhere in the stack.
+
+## 3. Richer gRPC/HTTP without new columns
+
+- **New RPCs** that filter/sort **existing** rows (e.g. “my upcoming”, “cancelled last 30d”) using current indexes.
+- **Field masks** or optional `include_*` flags in the proto to return computed strings (status labels, formatted windows) from the same row.
+
+## 4. Validation-only endpoints
+
+- **Dry-run create**: validate dates, overlap rules, and listing policy **without** inserting (or use a transaction rolled back in tests only—still no schema change).
+- **Quote / estimate**: return price breakdown from **in-code** rules + listing snapshot already on the booking payload.
+
+## 5. Eventing (Kafka) without new tables
+
+- Emit **richer CloudEvents** (or protobuf envelope) on **existing** lifecycle transitions: `BookingCreated`, `Confirmed`, `Cancelled`.
+- Downstream **analytics** or **notifications** consume new fields in the **payload** only; outbox row can remain the same shape if it stores opaque payload bytes.
+
+## 6. Policy engine in code
+
+- Centralize **eligibility** (min notice, max stay, blackout windows) in a **pure module** tested with Vitest; booking-service calls it before write.
+- Swap rules via **config map** / env JSON—no DDL.
+
+## 7. External calendar / ICS (optional)
+
+- Generate **ICS** or feed links from **existing** booking rows (read-only export); no persistence of calendar IDs required initially.
+
+## 8. Observability and SLO hooks
+
+- Add **RED metrics** histograms for `CreateBooking`, `Confirm` (latency, success rate).
+- **Trace attributes**: `listing_id`, `tenant_id` on spans—debug cross-service without DB.
+
+## 9. Compatibility shims
+
+- **Versioned protos** (`v2` package) with deprecated fields kept optional—deploy gateway + service together; DB unchanged.
+
+---
+
+**When you truly need DDL:** long-lived audit history, dispute resolution state, or multi-step workflows that must survive Redis loss—plan a migration; until then, the above keeps product iteration unblocked.

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ SKIP_VERIFY_CURL_HTTP3 ?= 0
 .DEFAULT_GOAL := menu
 
 .PHONY: menu help setup reset verify diagnose clean-data-modeling-png generate-diagrams generate-uml generate-architecture bundle-2.1-submission generate-architecture-docs kafka-broker-status-stub db-schema-er-docs index-audit-md real-query-plan-suite up up-fast deps kubeconfig-colima cluster colima-net colima-patch-app-config-db-gateway tls-first-time trust-ca-macos verify-curl-http3 verify-docker-ports recycle-postgres-infra infra-host infra-cluster \
-	metallb-fix hosts-sanity ensure-edge-hosts wait-for-caddy-ip preflight-gate sslkeylog-seed ollama-note ollama-env verify-network-coherence verify-kafka-bootstrap verify-kafka-cluster check-kafka-config-drift kafka-runtime-sync kafka-sync-metallb kafka-heal-inter-broker-tls kafka-alignment-suite kafka-health kafka-smoke kafka-smoke-with-health k8s-diagnose-restarts post-deploy-verify golden-snapshot chaos-suite-kafka verify-preflight-edge-routing diagnose-k6-edge cleanup-kafka-ops-pods apply-kafka-kraft kafka-refresh-tls-from-lb kafka-tls-rotate-atomic kafka-tls-guard kafka-tls-guard-remediate kafka-quorum-stable service-tls-alias-guard edge-readiness-gate onboarding-kafka-preflight kafka-onboarding-reset kafka-lb-reset kafka-headless-reset kafka-clean-slate kafka-rolling-restart onboarding-edge dev-onboard dev-onboard-hardened-reset dev-onboard-eks dev-onboard-lite ephemeral-k3s-smoke chaos-kafka-broker chaos-metallb-kafka-lb chaos-test sync-prometheus-kafka-rules colima-bridged colima-bridged-clean metallb-bring-up test test-current model summarize-ceiling strict-canonical ceiling collapse-trust collapse-messaging collapse-all \
+	metallb-fix hosts-sanity ensure-edge-hosts wait-for-caddy-ip preflight-gate sslkeylog-seed ollama-note ollama-env verify-network-coherence verify-kafka-dns kafka-diagnose-broker-dns verify-kafka-bootstrap verify-kafka-cluster check-kafka-config-drift kafka-runtime-sync kafka-sync-metallb kafka-heal-inter-broker-tls kafka-alignment-suite kafka-health kafka-smoke kafka-smoke-with-health k8s-diagnose-restarts post-deploy-verify golden-snapshot chaos-suite-kafka verify-preflight-edge-routing diagnose-k6-edge cleanup-kafka-ops-pods apply-kafka-kraft kafka-refresh-tls-from-lb kafka-tls-rotate-atomic kafka-tls-guard kafka-tls-guard-remediate kafka-quorum-stable service-tls-alias-guard edge-readiness-gate rollout-och-full onboarding-kafka-preflight kafka-onboarding-reset kafka-lb-reset kafka-headless-reset kafka-clean-slate kafka-rolling-restart onboarding-edge dev-onboard dev-onboard-hardened-reset dev-onboard-eks dev-onboard-lite ephemeral-k3s-smoke chaos-kafka-broker chaos-metallb-kafka-lb chaos-test sync-prometheus-kafka-rules colima-bridged colima-bridged-clean metallb-bring-up test test-current model summarize-ceiling strict-canonical ceiling collapse-trust collapse-messaging collapse-all \
 	protocol-matrix packet-capture perf-lab perf-full generate-report graph-capacity heatmap-tail compare-run regression-guard \
 	slack-report discord-report ci ci-full certify ceiling-default performance-lab-interpret performance-lab-interpret-latest performance-lab-one capacity-recommend capacity-one protocol-happiness transport-routing-hints transport-routing-hints-sync-k8s perf-lab-dashboards bundle-performance-lab-10 strict-envelope-check adaptive-pool-suggest declare-readiness shellcheck-preflight transport-lab full-edge-transport-validation endpoint-coverage collapse-smoke explain-all-dbs demo demo-network demo-full demo-k3d stack images images-all kustomize-apply \
 	deploy-dev rollouts preflight-metallb test-e2e-integrated packet-capture-standalone certify-production \
@@ -141,8 +141,10 @@ help: ## List targets and short descriptions
 	@echo ""
 	@echo "Core:"
 	@echo "  make up               Full bootstrap (cluster + infra + TLS + /etc/hosts for edge; no KRaft / no deploy-dev)"
-	@echo "  make dev-onboard      Strict local onboard (Phase 10: full kafka-alignment-suite; SAFE_ONLY=1 → kafka-health); make setup alias"
+	@echo "  make dev-onboard      deps + zero-trust CA + up-fast + Kafka TLS + och-kafka-ssl-secret verify (Phase 10: alignment; SAFE_ONLY=1 → kafka-health); make setup alias"
+	@echo "  make rollout-och-full  After Kafka/TLS secret fixes: ensure cluster secrets + restart all housing apps + Caddy (ordered)"
 	@echo "  make kafka-heal-inter-broker-tls  Recreate kafka-0..N-1 if CrashLoop / PKIX JKS drift (see Runbook.md)"
+	@echo "  make kafka-diagnose-broker-dns  ENOTFOUND kafka-0.kafka...? (headless svc, pods, EndpointSlices)"
 	@echo "  make dev-onboard-eks  EKS: verify Kafka + edge only (no MetalLB/hosts reset)"
 	@echo "  make dev-onboard-lite CI-safe static checks (scripts + kustomize + client dry-run)"
 	@echo "  make kafka-smoke / kafka-smoke-with-health / post-deploy-verify  Live cluster gates (see Actions: Post-deploy verify)"
@@ -287,7 +289,7 @@ deps: ## Install workspace deps + Playwright browser; ensure cluster script exec
 	  exit 1; \
 	fi; \
 	cd $(REPO_ROOT) && pnpm install && pnpm --filter webapp exec playwright install chromium
-	chmod +x $(SCRIPTS)/setup-new-colima-cluster.sh $(SCRIPTS)/ensure-edge-hosts.sh $(SCRIPTS)/kafka-onboarding-reset.sh $(SCRIPTS)/kafka-clean-slate.sh $(SCRIPTS)/apply-kafka-kraft-staged.sh $(SCRIPTS)/ensure-dev-root-ca.sh $(SCRIPTS)/kafka-refresh-tls-from-lb.sh $(SCRIPTS)/wait-for-kafka-external-lb-ips.sh $(SCRIPTS)/detect-k8s-environment.sh $(SCRIPTS)/dev-onboard-local.sh $(SCRIPTS)/kafka-rolling-restart.sh $(SCRIPTS)/kafka-tls-guard.sh $(SCRIPTS)/kafka-after-rollout-verify-brokers.sh $(SCRIPTS)/kafka-auto-heal-inter-broker-tls.sh $(SCRIPTS)/kafka-tls-rotate-atomic.sh $(SCRIPTS)/export-kafka-ca-metric.sh $(SCRIPTS)/rollout-deferred-after-kafka-tls.sh $(SCRIPTS)/kafka-quorum-stable.sh $(SCRIPTS)/service-tls-alias-guard.sh $(SCRIPTS)/edge-readiness-gate.sh $(SCRIPTS)/generate-canonical-dev-tls.sh $(SCRIPTS)/verify-kafka-no-static-advertised-env.sh $(SCRIPTS)/check-kafka-config-drift.sh $(SCRIPTS)/kafka-runtime-sync.sh $(SCRIPTS)/kafka-sync-metallb.sh $(SCRIPTS)/tests/kafka-alignment-suite.sh $(SCRIPTS)/chaos-kafka-alignment-stochastic.sh $(SCRIPTS)/golden-snapshot-verify.sh $(SCRIPTS)/auth-outbox-inspect.sh $(SCRIPTS)/auth-outbox-replay.sh
+	chmod +x $(SCRIPTS)/setup-new-colima-cluster.sh $(SCRIPTS)/ensure-edge-hosts.sh $(SCRIPTS)/kafka-onboarding-reset.sh $(SCRIPTS)/kafka-clean-slate.sh $(SCRIPTS)/apply-kafka-kraft-staged.sh $(SCRIPTS)/ensure-dev-root-ca.sh $(SCRIPTS)/dev-onboard-zero-trust-preflight.sh $(SCRIPTS)/kafka-refresh-tls-from-lb.sh $(SCRIPTS)/wait-for-kafka-external-lb-ips.sh $(SCRIPTS)/detect-k8s-environment.sh $(SCRIPTS)/dev-onboard-local.sh $(SCRIPTS)/kafka-rolling-restart.sh $(SCRIPTS)/kafka-tls-guard.sh $(SCRIPTS)/kafka-after-rollout-verify-brokers.sh $(SCRIPTS)/kafka-auto-heal-inter-broker-tls.sh $(SCRIPTS)/kafka-tls-rotate-atomic.sh $(SCRIPTS)/export-kafka-ca-metric.sh $(SCRIPTS)/rollout-deferred-after-kafka-tls.sh $(SCRIPTS)/kafka-quorum-stable.sh $(SCRIPTS)/service-tls-alias-guard.sh $(SCRIPTS)/edge-readiness-gate.sh $(SCRIPTS)/generate-canonical-dev-tls.sh $(SCRIPTS)/verify-kafka-no-static-advertised-env.sh $(SCRIPTS)/check-kafka-config-drift.sh $(SCRIPTS)/kafka-runtime-sync.sh $(SCRIPTS)/kafka-sync-metallb.sh $(SCRIPTS)/tests/kafka-alignment-suite.sh $(SCRIPTS)/chaos-kafka-alignment-stochastic.sh $(SCRIPTS)/golden-snapshot-verify.sh $(SCRIPTS)/auth-outbox-inspect.sh $(SCRIPTS)/auth-outbox-replay.sh
 
 # ROLE: DEV — optional kubeconfig export helper
 kubeconfig-colima: ## Print/export Colima kubeconfig path for current shell
@@ -337,6 +339,12 @@ tls-first-time: ## Canonical TLS: reissue → Envoy client cert → strict boots
 verify-kafka-dns: ## Requires kubectl context; fails if kafka-N DNS slice ≠ pod IP
 	bash -n $(REPO_ROOT)/scripts/validate-kafka-dns.sh
 	$(REPO_ROOT)/scripts/validate-kafka-dns.sh
+
+# ROLE: DEV/SRE — analytics-service ENOTFOUND kafka-0.kafka...? Headless svc, Ready pods, EndpointSlices, nslookup probe
+kafka-diagnose-broker-dns: ## Diagnose broker DNS / ENOTFOUND (HOUSING_NS); then: verify-kafka-dns, apply-kafka-kraft
+	bash -n $(REPO_ROOT)/scripts/diagnose-kafka-broker-dns.sh
+	chmod +x $(REPO_ROOT)/scripts/diagnose-kafka-broker-dns.sh
+	HOUSING_NS=$(HOUSING_NS) bash $(REPO_ROOT)/scripts/diagnose-kafka-broker-dns.sh
 
 preflight-kafka-k8s: ## Broker props + DNS + ensure event topics (RF=3, min ISR=2); needs kubectl
 	bash -n $(REPO_ROOT)/scripts/preflight-kafka-k8s-rollout.sh
@@ -528,6 +536,11 @@ edge-readiness-gate: ## MetalLB IP on caddy-h3 + in-pod Caddy + api-gateway /hea
 	chmod +x $(SCRIPTS)/edge-readiness-gate.sh
 	NS_ING=$(NS_ING) HOUSING_NS=$(HOUSING_NS) bash $(SCRIPTS)/edge-readiness-gate.sh
 
+# Refresh Kafka TLS alias + ordered restart of every housing Deployment and caddy-h3 (picks up Secret mounts).
+rollout-och-full: ## ensure-housing-cluster-secrets then rollout-deferred-after-kafka-tls; skip secrets: SKIP_ENSURE_CLUSTER_SECRETS=1
+	chmod +x $(SCRIPTS)/ensure-housing-cluster-secrets.sh $(SCRIPTS)/rollout-deferred-after-kafka-tls.sh $(SCRIPTS)/rollout-restart-och-full-stack.sh
+	NS_ING=$(NS_ING) HOUSING_NS=$(HOUSING_NS) OCH_ROLLOUT_STATUS_TIMEOUT=$(OCH_ROLLOUT_STATUS_TIMEOUT) SKIP_ENSURE_CLUSTER_SECRETS=$(SKIP_ENSURE_CLUSTER_SECRETS) bash $(SCRIPTS)/rollout-restart-och-full-stack.sh
+
 # DESTRUCTIVE: wipes Kafka; requires existing cluster + ingress NS. Does not run make up or Docker.
 dev-onboard-hardened-reset: ## Kafka clean slate → canonical TLS reissue-only → ensure secrets → apply-kafka → guards → housing rollouts
 	@echo "⚠️  dev-onboard-hardened-reset destroys Kafka broker data (KAFKA_CLEAN_SLATE_CONFIRM=YES)"
@@ -566,8 +579,9 @@ onboarding-edge: ## verify-preflight-edge-routing (MetalLB + hosts + TLS)
 	$(MAKE) verify-preflight-edge-routing
 
 # ROLE: DEV — deterministic local onboard (EKS: dev-onboard-eks). Wrapper: scripts/dev-onboard-local.sh (set -euo pipefail).
-dev-onboard: ## LOCAL: phased onboard + TLS/Kafka gates + full Kafka alignment post-edge (DEV_ONBOARD_KAFKA_ALIGNMENT_SAFE_ONLY=1 → kafka-health; SKIP_KAFKA_HEALTH_ON_ONBOARD=1 skips); EKS: verify-only
-	@chmod +x $(SCRIPTS)/detect-k8s-environment.sh $(SCRIPTS)/dev-onboard-local.sh
+# Local path: Phase 0.25 deps + 0.5 dev-root CA → up-fast → Kafka apply → och-kafka-ssl-secret sync+verify → … (see script header).
+dev-onboard: ## LOCAL: deps + zero-trust CA + up-fast + Kafka/housing TLS gates + alignment (DEV_ONBOARD_KAFKA_ALIGNMENT_SAFE_ONLY=1 → kafka-health); EKS: verify-only
+	@chmod +x $(SCRIPTS)/detect-k8s-environment.sh $(SCRIPTS)/dev-onboard-local.sh $(SCRIPTS)/dev-onboard-zero-trust-preflight.sh $(SCRIPTS)/ensure-dev-root-ca.sh $(SCRIPTS)/ensure-housing-cluster-secrets.sh
 	@_och_env=$$(bash $(SCRIPTS)/detect-k8s-environment.sh 2>/dev/null || echo LOCAL); \
 	if [ "$$_och_env" = "EKS" ]; then \
 	  $(MAKE) dev-onboard-eks; \
@@ -616,6 +630,10 @@ dev-onboard-lite: ## CI-safe: bash -n scripts, kustomize kafka bundle, onboard s
 	bash -n "$(SCRIPTS)/ci/ephemeral-k3s-converge.sh"; \
 	grep -q 'generate-canonical-dev-tls.sh' "$(REPO_ROOT)/Makefile"; \
 	grep -q 'apply-kafka-kraft' "$(SCRIPTS)/dev-onboard-local.sh"; \
+	grep -q 'dev-onboard-zero-trust-preflight' "$(SCRIPTS)/dev-onboard-local.sh"; \
+	grep -q 'Phase 3.5' "$(SCRIPTS)/dev-onboard-local.sh"; \
+	grep -q 'Phase 0.25' "$(SCRIPTS)/dev-onboard-local.sh"; \
+	grep -q 'up-fast' "$(SCRIPTS)/dev-onboard-local.sh"; \
 	grep -q 'kafka-refresh-tls-from-lb' "$(SCRIPTS)/apply-kafka-kraft-staged.sh"; \
 	grep -q 'kafka-quorum-stable' "$(SCRIPTS)/dev-onboard-local.sh"; \
 	grep -q 'service-tls-alias-guard' "$(SCRIPTS)/dev-onboard-local.sh"; \

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,71 @@
+# Summary
+
+This PR focuses on **local onboarding / Kafka TLS** (so app pods get **`och-kafka-ssl-secret`** before deploy), **operability** for **Kafka broker DNS** failures (`ENOTFOUND kafka-0.kafka…`), and **reference material** for booking-service growth **without** DB migrations. **`webapp` UI matches `origin/main`**—community, booking routes, messaging sidebar, and related demo UI were **removed from this branch** to narrow scope (those experiments live on the saved branch below).
+
+## Infra / onboarding / Kafka
+
+- **`make dev-onboard`**: Phase **0.25** **`make deps`**, **0.5** **`dev-onboard-zero-trust-preflight`**, **1** **`make up-fast`**, **3.5** sync + **verify** **`och-kafka-ssl-secret`** (`ca-cert.pem`, `client.crt`, `client.key`) with **remediation** (`kafka-ssl-from-dev-root.sh` + Kafka STS restart when needed).
+- **`make rollout-och-full`** + **`scripts/rollout-restart-och-full-stack.sh`**: **`ensure-housing-cluster-secrets`** then ordered housing Deployments + **caddy-h3**.
+- **`make kafka-diagnose-broker-dns`**: diagnose **`ENOTFOUND kafka-0.kafka.<namespace>.svc.cluster.local`**—headless **`Service/kafka`**, **`StatefulSet/kafka`**, **Ready** **`kafka-0..2`**, **`validate-kafka-dns.sh`**, **`app-config`** snippet.
+- **README** quick start notes the **dev-onboard** TLS chain.
+
+## Webapp (aligned with `main`)
+
+- No **`/community`**, **`/booking`**, **MessagingSidebar**, **ClientChrome**, or **ListingBookingModal** on this branch.
+- **Optional screenshots** (`E2E_SCREENSHOTS=1`, project **05-optional-screenshots**): **01–07** only (home, login, register, listings, mission, trust, analytics)—same as **`main`**.
+
+## Reference doc (no product code)
+
+- **`BOOKING_SERVICE_EXPANSION_NO_DB.md`** — ideas to extend **booking-service** via API composition, Redis overlays, events, and observability **without** schema changes.
+
+## Teammate handoff — fuller webapp + analytics metrics UI
+
+Earlier iteration (community, messaging UI, booking page, analytics metrics cards, extended screenshots) is preserved on **`saved/feat-webapp-analytics-ui-full`** (`origin`).
+
+```bash
+git fetch origin
+git checkout -b feat/analytics-ui origin/saved/feat-webapp-analytics-ui-full
+# or restore single files, e.g.:
+git checkout saved/feat-webapp-analytics-ui-full -- webapp/app/analytics/page.tsx
+```
+
+**This PR** keeps **`webapp/app/analytics/page.tsx`** at the **pre–metrics-cards** shell (reverted earlier in branch history).
+
+# Why
+
+- Teammates were blocked on **missing Kafka client PEM secrets** and on **broker DNS** when **`analytics-service`** (and others) could not resolve **`kafka-0.kafka.<namespace>.svc.cluster.local`**.
+- Canonical **`make dev-onboard`** should create and **verify** **`och-kafka-ssl-secret`** before app rollouts.
+- Narrow **webapp** diff vs **`main`** avoids shipping large UI experiments in the same PR as infra fixes.
+- **Booking** expansion notes support planning without committing to DDL.
+
+# Test plan
+
+## Webapp / Playwright (strict edge)
+
+```bash
+E2E_RELAX_ANALYTICS_METRICS=1 ./scripts/webapp-playwright-strict-edge.sh
+
+E2E_SCREENSHOTS=1 ./scripts/webapp-playwright-strict-edge.sh --project=05-optional-screenshots
+```
+
+- After screenshots: **`webapp/e2e/screenshots/`** should include **01–07** (PNGs are **gitignored**).
+
+## Onboarding (manual / local)
+
+```bash
+make images
+make dev-onboard   # optional: RESTORE_BACKUP_DIR=latest make dev-onboard
+```
+
+- Completes without **Phase 3.5** **`och-kafka-ssl-secret`** verification failures.
+- **`kubectl get secret och-kafka-ssl-secret -n off-campus-housing-tracker -o json | jq '.data | keys'`** includes **`ca-cert.pem`**, **`client.crt`**, **`client.key`**.
+
+## Kafka DNS (when analytics logs `ENOTFOUND kafka-0.kafka…`)
+
+```bash
+make kafka-diagnose-broker-dns
+# then as needed:
+make verify-kafka-dns
+make kafka-onboarding-reset && make apply-kafka-kraft
+make kafka-tls-guard
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 make images
 
 # 2. Full local stack (~20–28 min first time; see docs/DEV_ONBOARDING.md)
+#    dev-onboard: pnpm deps → dev-root CA → cluster (up-fast) → Kafka TLS → sync+verify och-kafka-ssl-secret → deploy
 RESTORE_BACKUP_DIR=latest make dev-onboard   # restore newest Postgres backups; or: make dev-onboard (no restore)
 ```
 

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,33 +1,10 @@
-fix(ci,auth,kafka,vitest): auth outbox + backup; och-ci; Kafka TLS gates; integration/system Vitest + preflight stack
+chore(webapp): defer analytics metrics cards UI to branch saved/feat-webapp-analytics-ui-full
 
-Auth
-- Dual transactional outbox (auth_outbox + outbox_events): SQL, verify-bootstrap /
-  inspect-external-db-schemas, index fixes; backup bundle aligned with all-8 restore.
-- rebuild-housing-colima logging (ok/warn) where applicable.
+The polished daily-metrics card grid and related analytics UI live on branch
+saved/feat-webapp-analytics-ui-full (snapshot of this work before this change).
+This branch keeps the simpler analytics shell from main-line history.
 
-CI (och-ci)
-- Integration job keeps plaintext Kafka service containers for packages that need a broker;
-  bounded waits and parallel batches unchanged where documented.
-- transport-validation: if: always() after integration-tests so cancelled integration does
-  not leave a misleading skip in the aggregate gate.
-- on.push branch filters restored (fix/, feat/, etc.); concurrency keyed by event_name so
-  push and pull_request runs do not cancel each other. See docs/CI_CHECK_RUNS.md.
+Teammate: merge or cherry-pick from saved/feat-webapp-analytics-ui-full, or
+restore the file with: git checkout saved/feat-webapp-analytics-ui-full -- webapp/app/analytics/page.tsx
 
-Kafka / local cluster
-- Inter-broker TLS heal hooks, sync-metallb pre-heal, dev-onboard alignment defaults;
-  Runbook / zero-trust checklist updates as in branch.
-- Vitest cluster policy: ≥3 TLS seeds, PEM on disk, RF metadata check, assert script before
-  listings/booking integration; scripts/assert-kafka-integration-cluster.mjs + services/common
-  kafka-vitest-cluster helper.
-
-Vitest orchestration
-- test:integration:all, test:system, test:vitest-stack, test:smoke (full stack); make
-  test-vitest-stack builds @common then runs test:vitest-stack.
-- Preflight step 7a0c: PREFLIGHT_RUN_REPO_VITEST_STACK defaults to 1 — after event-layer,
-  pnpm -C services/common build && pnpm run test:vitest-stack. Set
-  PREFLIGHT_RUN_REPO_VITEST_STACK=0 to skip. PREFLIGHT_RUN_SYSTEM_CONTRACTS only applies when
-  the stack step is off.
-
-Docs: vitest-per-service-requirements.md, integration-test-tiers.md, system-test-rules.md.
-
-Made with Tom.
+Made-with: Tom

--- a/scripts/dev-onboard-local.sh
+++ b/scripts/dev-onboard-local.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Strict local (Colima/k3s + MetalLB) dev-onboard orchestration: set -euo pipefail, no silent success.
 #
+# Prevents app CrashLoop when Secret/och-kafka-ssl-secret is missing or incomplete (auth-service,
+# analytics-service, etc. mount /etc/kafka/secrets/ca-cert.pem, client.crt, client.key for Kafka mTLS).
+#
 # Deterministic contract (gates before later phases):
-#   TLS: defer Kafka JKS until LB (TLS_FIRST_TIME_DEFER_KAFKA_JKS); reissue syncs och-service-tls (reissue step 2c);
-#        Phase 5 kafka-tls-guard + 5a ensure-housing-cluster-secrets + 5a1 service-tls-alias-guard.
+#   Toolchain: Phase 0.25 make deps (pnpm for ensure-dev-root / reissue before Phase 0.5).
+#   TLS: Phase 0.5 local dev-root CA (dev-onboard-zero-trust-preflight) before make up-fast;
+#        defer Kafka JKS until LB (TLS_FIRST_TIME_DEFER_KAFKA_JKS); reissue syncs och-service-tls (reissue step 2c);
+#        Phase 3.5 ensure-housing-cluster-secrets + verify och-kafka-ssl-secret PEM keys right after apply-kafka-kraft;
+#        Phase 5 kafka-tls-guard + 5a ensure-housing-cluster-secrets (idempotent) + 5a1 service-tls-alias-guard.
 #   Kafka: Phase 5a2 kafka-quorum-stable (no QuorumController "leader is (none)" in window).
 #   Edge: Phase 5b deferred rollouts; Phase 7b edge-readiness-gate (MetalLB + Caddy + gateway /healthz + /readyz).
 #   Post-edge: Phase 10 default KAFKA_ALIGNMENT_TEST_MODE=1 make kafka-alignment-suite (full alignment + auto inter-broker TLS heal via Makefile).
@@ -68,6 +74,27 @@ make() {
   command make -C "$REPO_ROOT" "$@"
 }
 
+# Exit 0 iff Secret/och-kafka-ssl-secret has non-empty data for ca-cert.pem, client.crt, client.key.
+_verify_och_kafka_pem_secret() {
+  local ns="$1"
+  python3 -c "
+import json, subprocess, sys
+ns = sys.argv[1]
+r = subprocess.run(
+    ['kubectl', '-n', ns, 'get', 'secret', 'och-kafka-ssl-secret', '-o', 'json', '--request-timeout=25s'],
+    capture_output=True,
+    text=True,
+)
+if r.returncode != 0:
+    sys.exit(1)
+data = json.loads(r.stdout).get('data') or {}
+for k in ('ca-cert.pem', 'client.crt', 'client.key'):
+    if k not in data or not (data[k] or '').strip():
+        sys.exit(1)
+print('  ✅ och-kafka-ssl-secret verified (ca-cert.pem, client.crt, client.key)')
+" "$ns"
+}
+
 if [[ -n "${RESTORE_BACKUP_DIR:-}" ]]; then
   echo "▶ Phase 0: Docker Compose + 7 Postgres — restore from dumps only (no infra/db SQL here)"
   export SKIP_BOOTSTRAP=1
@@ -76,9 +103,16 @@ else
   echo "▶ Phase 0: skipped (RESTORE_BACKUP_DIR empty — infra-cluster may run SQL bootstrap)"
 fi
 
-echo "▶ Phase 1: Base cluster + TLS + host infra (no app Deployment restarts in reissue; RESTORE cleared for this make)"
+echo "▶ Phase 0.25: Workspace deps (pnpm install — required before dev-root / reissue in Phase 0.5)"
+make deps
+
+echo "▶ Phase 0.5: Zero-trust TLS — local dev-root CA before cluster (Kafka / mTLS signing chain)"
+chmod +x "$SCRIPT_DIR/dev-onboard-zero-trust-preflight.sh"
+bash "$SCRIPT_DIR/dev-onboard-zero-trust-preflight.sh"
+
+echo "▶ Phase 1: Base cluster + TLS + host infra (deps already done — up-fast; no app Deployment restarts in reissue; RESTORE cleared for this make)"
 export SKIP_AUTO_RESTORE=1
-RESTORE_BACKUP_DIR= make up
+RESTORE_BACKUP_DIR= make up-fast
 
 echo "▶ Phase 2: Kafka Service reset (LB + headless)"
 make kafka-onboarding-reset
@@ -86,13 +120,33 @@ make kafka-onboarding-reset
 echo "▶ Phase 3: Kafka Services + atomic TLS refresh (scale-0 → full JKS regen → brokers up; Parallel SS policy kept for KRaft DNS bootstrap)"
 make apply-kafka-kraft
 
+echo "▶ Phase 3.5: Housing secrets — sync och-kafka-ssl-secret (app Kafka mTLS PEMs) + verify keys"
+chmod +x "$SCRIPT_DIR/ensure-housing-cluster-secrets.sh"
+_NS="${HOUSING_NS:-off-campus-housing-tracker}"
+HOUSING_NS="$_NS" bash "$SCRIPT_DIR/ensure-housing-cluster-secrets.sh"
+if ! _verify_och_kafka_pem_secret "$_NS"; then
+  echo "▶ Phase 3.5 remediate: kafka-ssl-from-dev-root.sh + re-sync (broker PEM material → och-kafka-ssl-secret)"
+  chmod +x "$SCRIPT_DIR/kafka-ssl-from-dev-root.sh"
+  KAFKA_SSL_NS="$_NS" bash "$SCRIPT_DIR/kafka-ssl-from-dev-root.sh"
+  if kubectl get sts kafka -n "$_NS" --request-timeout=20s >/dev/null 2>&1; then
+    echo "  ▶ rollout restart statefulset/kafka (brokers remount kafka-ssl-secret)"
+    kubectl rollout restart statefulset/kafka -n "$_NS" --request-timeout=30s
+    kubectl rollout status statefulset/kafka -n "$_NS" --timeout=480s
+  fi
+  HOUSING_NS="$_NS" bash "$SCRIPT_DIR/ensure-housing-cluster-secrets.sh"
+  if ! _verify_och_kafka_pem_secret "$_NS"; then
+    echo "❌ och-kafka-ssl-secret still incomplete — check kubectl context, namespace $_NS, and certs/dev-root.{pem,key}" >&2
+    exit 1
+  fi
+fi
+
 echo "▶ Phase 4: Kafka DNS + topic preflight + bootstrap"
 make onboarding-kafka-preflight
 
 echo "▶ Phase 5: Kafka TLS guard (mounted CA + JKS uniformity, service-tls↔Kafka CA, PKIX logs) + verify-kafka-cluster — abort onboard if this fails"
 make kafka-tls-guard
 
-echo "▶ Phase 5a: Sync och-service-tls / och-kafka aliases from canonical secrets (idempotent)"
+echo "▶ Phase 5a: Re-sync och-service-tls / och-kafka aliases (idempotent; after TLS guard churn)"
 HOUSING_NS="${HOUSING_NS:-off-campus-housing-tracker}" bash "$SCRIPT_DIR/ensure-housing-cluster-secrets.sh"
 
 echo "▶ Phase 5a1: service-tls ↔ och-service-tls CA fingerprint gate (alias drift fail-fast)"

--- a/scripts/dev-onboard-zero-trust-preflight.sh
+++ b/scripts/dev-onboard-zero-trust-preflight.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# First step of local dev-onboard (before make up): ensure the dev-root CA exists on disk.
+# Kafka broker/client TLS and strict mTLS services are signed from this chain; without it,
+# tls-first-time / kafka-refresh cannot produce kafka-ssl-secret or och-kafka-ssl-secret.
+#
+# Cluster-agnostic — safe before Colima/k3s. Does not kubectl apply.
+#
+# Usage: ./scripts/dev-onboard-zero-trust-preflight.sh
+# Env: same as scripts/ensure-dev-root-ca.sh (e.g. KAFKA_REMEDIATE_SKIP_REISSUE=1 to fail if CA missing)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Zero-trust TLS preflight (local CA before cluster) ==="
+echo "  After Kafka TLS refresh, dev-onboard syncs Secret/och-kafka-ssl-secret (keys: ca-cert.pem, client.crt, client.key) for app pods."
+chmod +x "$SCRIPT_DIR/ensure-dev-root-ca.sh"
+bash "$SCRIPT_DIR/ensure-dev-root-ca.sh"
+echo "✅ certs/dev-root.pem + dev-root.key present — continuing to cluster / TLS bootstrap"

--- a/scripts/diagnose-kafka-broker-dns.sh
+++ b/scripts/diagnose-kafka-broker-dns.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Diagnose "getaddrinfo ENOTFOUND kafka-0.kafka.<ns>.svc.cluster.local" (analytics / any KafkaJS client).
+# Root causes: headless Service `kafka` missing, StatefulSet pods not Ready, stale EndpointSlices, wrong namespace.
+#
+# Usage: HOUSING_NS=off-campus-housing-tracker ./scripts/diagnose-kafka-broker-dns.sh
+# Remediation hints: make verify-kafka-dns, make kafka-onboarding-reset && make apply-kafka-kraft, validate-kafka-dns.sh
+set -euo pipefail
+
+NS="${HOUSING_NS:-off-campus-housing-tracker}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+say() { printf "\n\033[1m%s\033[0m\n" "$*"; }
+ok() { echo "  ✅ $*"; }
+warn() { echo "  ⚠️  $*" >&2; }
+bad() { echo "  ❌ $*" >&2; }
+
+say "Kafka broker DNS diagnostic (namespace=$NS)"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  bad "kubectl not in PATH"
+  exit 1
+fi
+
+if ! kubectl get ns "$NS" --request-timeout=15s >/dev/null 2>&1; then
+  bad "Namespace $NS not found — set HOUSING_NS or create namespace"
+  exit 1
+fi
+ok "Namespace exists"
+
+if ! kubectl get svc kafka -n "$NS" --request-timeout=15s >/dev/null 2>&1; then
+  bad "Service/kafka (headless) missing — apply infra/k8s/kafka-kraft-metallb/headless-service.yaml (see make apply-kafka-kraft)"
+  exit 1
+fi
+cluster_ip="$(kubectl get svc kafka -n "$NS" -o jsonpath='{.spec.clusterIP}' --request-timeout=15s)"
+if [[ "$cluster_ip" != "None" ]]; then
+  bad "Service/kafka is not headless (clusterIP should be None; got $cluster_ip)"
+  exit 1
+fi
+ok "Headless Service/kafka exists (clusterIP=None)"
+
+if ! kubectl get sts kafka -n "$NS" --request-timeout=15s >/dev/null 2>&1; then
+  bad "StatefulSet/kafka missing — brokers never created"
+  exit 1
+fi
+ok "StatefulSet/kafka exists"
+
+fail_pods=0
+for i in 0 1 2; do
+  pod="kafka-$i"
+  if ! kubectl get pod "$pod" -n "$NS" --request-timeout=15s >/dev/null 2>&1; then
+    bad "Pod $pod not found"
+    fail_pods=1
+    continue
+  fi
+  phase="$(kubectl get pod "$pod" -n "$NS" -o jsonpath='{.status.phase}' --request-timeout=15s)"
+  ready="$(kubectl get pod "$pod" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' --request-timeout=15s)"
+  echo "  Pod $pod: phase=$phase Ready=$ready"
+  if [[ "$phase" != "Running" || "$ready" != "True" ]]; then
+    bad "$pod not Running/Ready — DNS will not resolve stable broker names"
+    fail_pods=1
+  fi
+done
+
+if [[ "$fail_pods" -ne 0 ]]; then
+  say "Remediation (pods unhealthy)"
+  echo "  kubectl describe pod kafka-0 -n $NS"
+  echo "  kubectl logs kafka-0 -n $NS -c kafka --tail=80"
+  echo "  make kafka-tls-guard   # JKS / TLS drift"
+  echo "  make apply-kafka-kraft # re-apply KRaft + external svcs"
+  exit 1
+fi
+ok "Broker pods kafka-0..2 exist"
+
+fqdn="kafka-0.kafka.${NS}.svc.cluster.local"
+say "In-cluster FQDN (expect A record when headless Endpoints are healthy): $fqdn"
+echo "  From a Running pod in $NS, run:"
+echo "    getent hosts $fqdn || nslookup $fqdn"
+echo "  NXDOMAIN / no answer → CoreDNS cannot see EndpointSlices for Service/kafka (stale slices or pods not Ready)."
+
+say "EndpointSlice vs pod IP (stale slices → wrong A records)"
+if [[ -x "$SCRIPT_DIR/validate-kafka-dns.sh" ]]; then
+  KAFKA_NAMESPACE="$NS" bash "$SCRIPT_DIR/validate-kafka-dns.sh" && ok "validate-kafka-dns.sh passed" || {
+    bad "validate-kafka-dns.sh failed — fix slices / rollout kafka"
+    echo "  kubectl get endpointslice -n $NS -l kubernetes.io/service-name=kafka"
+    echo "  See scripts/validate-kafka-dns.sh hints"
+    exit 1
+  }
+else
+  warn "validate-kafka-dns.sh not executable — chmod +x scripts/validate-kafka-dns.sh"
+fi
+
+say "App-config bootstrap string (should list kafka-0..2 :9093 internal TLS)"
+if kubectl get configmap app-config -n "$NS" -o yaml --request-timeout=15s 2>/dev/null | grep -E "KAFKA|kafka" | head -15; then
+  ok "app-config snippet above"
+else
+  warn "configmap app-config not found or empty Kafka keys"
+fi
+
+echo ""
+ok "Diagnostic complete — if ENOTFOUND persists: ensure headless kafka Service + Ready kafka-0..2 + EndpointSlices match pod IPs"

--- a/scripts/rollout-restart-och-full-stack.sh
+++ b/scripts/rollout-restart-och-full-stack.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Full-stack ordered rollout: refresh housing Secrets (Kafka client PEM alias, service-tls mirrors),
+# then restart every OCH app Deployment and caddy-h3 so pods remount Secrets.
+#
+# Use when:
+#   - Kafka TLS was fixed (kafka-ssl-from-dev-root.sh) but pods still see empty /etc/kafka/secrets
+#   - Any Secret used as a volume changed (Kubernetes does not remount live)
+#   - You want one command instead of ad-hoc per-service rollout restart
+#
+# Order: auth → listings → booking → messaging → trust → analytics → media → notification →
+#   api-gateway → caddy-h3 (see scripts/lib/och-sequential-rollout.sh).
+#
+# Env:
+#   HOUSING_NS — default off-campus-housing-tracker
+#   NS_ING — default ingress-nginx
+#   SKIP_ENSURE_CLUSTER_SECRETS=1 — skip ensure-housing-cluster-secrets.sh (rollout only)
+#   OCH_ROLLOUT_STATUS_TIMEOUT — seconds per rollout status (default 180)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+export PATH="$SCRIPT_DIR/shims:/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+
+export HOUSING_NS="${HOUSING_NS:-off-campus-housing-tracker}"
+export NS_ING="${NS_ING:-ingress-nginx}"
+
+echo "=== rollout-restart-och-full-stack (ns=$HOUSING_NS, ingress=$NS_ING) ==="
+
+if [[ "${SKIP_ENSURE_CLUSTER_SECRETS:-0}" != "1" ]]; then
+  echo "▶ ensure-housing-cluster-secrets (och-kafka-ssl-secret + och-service-tls aliases)"
+  HOUSING_NS="$HOUSING_NS" bash "$SCRIPT_DIR/ensure-housing-cluster-secrets.sh"
+else
+  echo "▶ skip ensure-housing-cluster-secrets (SKIP_ENSURE_CLUSTER_SECRETS=1)"
+fi
+
+echo "▶ ordered rollout: all housing Deployments, then caddy-h3"
+bash "$SCRIPT_DIR/rollout-deferred-after-kafka-tls.sh"
+
+echo "✅ rollout-restart-och-full-stack complete"

--- a/webapp/e2e/listings-filters-maps.spec.ts
+++ b/webapp/e2e/listings-filters-maps.spec.ts
@@ -161,6 +161,7 @@ test.describe("Listings filters & maps", () => {
     test.skip(!(await apiGatewayHealthy(request)), "edge not reachable");
     const id = await firstListingIdFromSearch(request);
     test.skip(!id, "no listings in search index — seed or create listings first");
+    if (!id) return;
 
     await page.goto("/listings");
     await expect(page.getByTestId("listings-results")).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });


### PR DESCRIPTION
# Summary

This PR focuses on **local onboarding / Kafka TLS** (so app pods get **`och-kafka-ssl-secret`** before deploy), **operability** for **Kafka broker DNS** failures (`ENOTFOUND kafka-0.kafka…`), and **reference material** for booking-service growth **without** DB migrations. **`webapp` UI matches `origin/main`**—community, booking routes, messaging sidebar, and related demo UI were **removed from this branch** to narrow scope (those experiments live on the saved branch below).

## Infra / onboarding / Kafka

- **`make dev-onboard`**: Phase **0.25** **`make deps`**, **0.5** **`dev-onboard-zero-trust-preflight`**, **1** **`make up-fast`**, **3.5** sync + **verify** **`och-kafka-ssl-secret`** (`ca-cert.pem`, `client.crt`, `client.key`) with **remediation** (`kafka-ssl-from-dev-root.sh` + Kafka STS restart when needed).
- **`make rollout-och-full`** + **`scripts/rollout-restart-och-full-stack.sh`**: **`ensure-housing-cluster-secrets`** then ordered housing Deployments + **caddy-h3**.
- **`make kafka-diagnose-broker-dns`**: diagnose **`ENOTFOUND kafka-0.kafka.<namespace>.svc.cluster.local`**—headless **`Service/kafka`**, **`StatefulSet/kafka`**, **Ready** **`kafka-0..2`**, **`validate-kafka-dns.sh`**, **`app-config`** snippet.
- **README** quick start notes the **dev-onboard** TLS chain.

## Webapp (aligned with `main`)

- No **`/community`**, **`/booking`**, **MessagingSidebar**, **ClientChrome**, or **ListingBookingModal** on this branch.
- **Optional screenshots** (`E2E_SCREENSHOTS=1`, project **05-optional-screenshots**): **01–07** only (home, login, register, listings, mission, trust, analytics)—same as **`main`**.

## Reference doc (no product code)

- **`BOOKING_SERVICE_EXPANSION_NO_DB.md`** — ideas to extend **booking-service** via API composition, Redis overlays, events, and observability **without** schema changes.

## Teammate handoff — fuller webapp + analytics metrics UI

Earlier iteration (community, messaging UI, booking page, analytics metrics cards, extended screenshots) is preserved on **`saved/feat-webapp-analytics-ui-full`** (`origin`).

```bash
git fetch origin
git checkout -b feat/analytics-ui origin/saved/feat-webapp-analytics-ui-full
# or restore single files, e.g.:
git checkout saved/feat-webapp-analytics-ui-full -- webapp/app/analytics/page.tsx
```

**This PR** keeps **`webapp/app/analytics/page.tsx`** at the **pre–metrics-cards** shell (reverted earlier in branch history).

# Why

- Teammates were blocked on **missing Kafka client PEM secrets** and on **broker DNS** when **`analytics-service`** (and others) could not resolve **`kafka-0.kafka.<namespace>.svc.cluster.local`**.
- Canonical **`make dev-onboard`** should create and **verify** **`och-kafka-ssl-secret`** before app rollouts.
- Narrow **webapp** diff vs **`main`** avoids shipping large UI experiments in the same PR as infra fixes.
- **Booking** expansion notes support planning without committing to DDL.

# Test plan

## Webapp / Playwright (strict edge)

```bash
E2E_RELAX_ANALYTICS_METRICS=1 ./scripts/webapp-playwright-strict-edge.sh

E2E_SCREENSHOTS=1 ./scripts/webapp-playwright-strict-edge.sh --project=05-optional-screenshots
```

- After screenshots: **`webapp/e2e/screenshots/`** should include **01–07** (PNGs are **gitignored**).

## Onboarding (manual / local)

```bash
make images
make dev-onboard   # optional: RESTORE_BACKUP_DIR=latest make dev-onboard
```

- Completes without **Phase 3.5** **`och-kafka-ssl-secret`** verification failures.
- **`kubectl get secret och-kafka-ssl-secret -n off-campus-housing-tracker -o json | jq '.data | keys'`** includes **`ca-cert.pem`**, **`client.crt`**, **`client.key`**.

## Kafka DNS (when analytics logs `ENOTFOUND kafka-0.kafka…`)

```bash
make kafka-diagnose-broker-dns
# then as needed:
make verify-kafka-dns
make kafka-onboarding-reset && make apply-kafka-kraft
make kafka-tls-guard
```
