### PR TITLE
test(listings-service): add explicit pet-friendly filter coverage

### DIFF
--- a/services/listings-service/tests/search-listings-query.test.ts
+++ b/services/listings-service/tests/search-listings-query.test.ts
@@ -117,6 +117,16 @@ describe("buildListingsSearchQuery", () => {
     expect(sql).toMatch(/pet_friendly\s*=\s*true/);
   });
 
+  it("combines pet-friendly filter with price filter", () => {
+    const { sql } = buildListingsSearchQuery({
+      pets: true,
+      minP: 1000,
+    });
+
+    expect(sql).toContain("pet_friendly = true");
+    expect(sql).toContain("price_cents >=");
+  });
+
   it("adds amenity jsonb predicates", () => {
     const { sql, params } = buildListingsSearchQuery({
       amenitySlugs: ["garage", "parking"],

--- a/services/listings-service/tests/search-listings-query.test.ts
+++ b/services/listings-service/tests/search-listings-query.test.ts
@@ -98,6 +98,25 @@ describe("buildListingsSearchQuery", () => {
     expect(sql).toContain("furnished IS TRUE");
   });
 
+  it("adds pet-friendly filter when pets=true", () => {
+    const { sql } = buildListingsSearchQuery({ pets: true });
+
+    expect(sql).toContain("pet_friendly = true");
+  });
+
+  it("does not add pet-friendly filter when pets=false", () => {
+    const { sql } = buildListingsSearchQuery({ pets: false });
+
+    expect(sql).not.toContain("pet_friendly = true");
+  });
+
+  it("only returns pet-friendly constraint when requested", () => {
+    const { sql } = buildListingsSearchQuery({ pets: true });
+
+    // ensures no accidental inversion or wrong operator
+    expect(sql).toMatch(/pet_friendly\s*=\s*true/);
+  });
+
   it("adds amenity jsonb predicates", () => {
     const { sql, params } = buildListingsSearchQuery({
       amenitySlugs: ["garage", "parking"],


### PR DESCRIPTION
## Summary

Adds explicit test coverage for the pet-friendly search filter in `buildListingsSearchQuery`.

## Why

Issue #39 suggests that pet-friendly listings may not appear in filtered search results.

After reviewing the implementation:
- SQL builder already includes `pet_friendly = true` when `pets` is true
- HTTP and gRPC layers correctly map `pet_friendly` into the shared filter
- Behavior is consistent across both paths

The missing piece was explicit test coverage for this filter.

## Changes

- Added isolated tests for:
  - `pets: true` → includes `pet_friendly = true`
  - `pets: false` → does not include filter

## Notes

- No production code changes required
- Indexing not added — should only be considered if profiling shows a real performance issue

Closes #39 