### PR TITLE
fix(webapp): resolve login/register redirect issue (#44)

### DIFF
--- a/webapp/app/login/page.tsx
+++ b/webapp/app/login/page.tsx
@@ -23,6 +23,12 @@ export default function LoginPage() {
       if (!data.token) throw new Error("No token returned");
       setStoredToken(data.token);
       setStoredEmail(email.trim());
+
+      if (typeof window !== "undefined") {
+        window.location.assign("/dashboard");
+        return;
+      }
+
       router.push("/dashboard");
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : "Login failed");

--- a/webapp/app/register/page.tsx
+++ b/webapp/app/register/page.tsx
@@ -23,6 +23,12 @@ export default function RegisterPage() {
       if (!data.token) throw new Error("No token returned");
       setStoredToken(data.token);
       setStoredEmail(email.trim());
+
+      if (typeof window !== "undefined") {
+        window.location.assign("/dashboard");
+        return;
+      }
+
       router.push("/dashboard");
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : "Registration failed");


### PR DESCRIPTION
## What this PR does
- Fixes redirect issue after login and registration
- Replaces client-side navigation with hard navigation using `window.location.assign`

## Why
Using `router.push("/dashboard")` caused inconsistent redirects due to client-side hydration/timing issues.  
In some cases, the dashboard would not detect the stored token immediately and redirect back to `/login`.

## Fix
- Switched to hard navigation after authentication to ensure token is available before dashboard loads
- Aligns with existing dashboard logic that already uses hard redirects for auth handling

## How to test
1. Start the webapp
2. Register a new account → should redirect to `/dashboard`
3. Log out (if available) and log back in → should redirect correctly
4. Refresh `/dashboard` → should stay authenticated

## Notes
- No backend changes required
- Keeps auth flow consistent and reliable

Closes #44 