### PR TITLE
refactor(webapp): centralize auth hydration state

### DIFF
--- a/webapp/app/dashboard/page.tsx
+++ b/webapp/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import {
   watchlistList,
   watchlistRemove,
 } from "@/lib/api";
-import { getStoredEmail, getStoredToken } from "@/lib/auth-storage";
+import { useAuth } from "@/lib/auth-context";
 import { Nav } from "@/components/Nav";
 import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
 
@@ -32,9 +32,7 @@ type WatchRow = {
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [ready, setReady] = useState(false);
-  const [token, setToken] = useState<string | null>(null);
-  const [email, setEmail] = useState<string | null>(null);
+  const { authReady, token, email, isAuthenticated } = useAuth();
 
   const [query, setQuery] = useState("near campus");
   const [minPrice, setMinPrice] = useState("");
@@ -47,25 +45,14 @@ export default function DashboardPage() {
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  /** Ignore stale responses when multiple refreshAll() calls overlap (initial load vs post-save). */
   const refreshGen = useRef(0);
 
   useEffect(() => {
-    const t = getStoredToken();
-    const em = getStoredEmail();
-    if (!t) {
-      // Hard navigation is more reliable than client router in Playwright / strict edge cases.
-      if (typeof window !== "undefined" && window.location.pathname.startsWith("/dashboard")) {
-        window.location.replace(`${window.location.origin}/login`);
-        return;
-      }
+    if (!authReady) return;
+    if (!isAuthenticated) {
       void router.replace("/login");
-      return;
     }
-    setToken(t);
-    setEmail(em);
-    setReady(true);
-  }, [router]);
+  }, [authReady, isAuthenticated, router]);
 
   const refreshAll = useCallback(async () => {
     if (!token) return;
@@ -89,8 +76,8 @@ export default function DashboardPage() {
   }, [token]);
 
   useEffect(() => {
-    if (ready && token) void refreshAll();
-  }, [ready, token, refreshAll]);
+    if (authReady && token) void refreshAll();
+  }, [authReady, token, refreshAll]);
 
   async function onSaveSearch(e: React.FormEvent) {
     e.preventDefault();
@@ -151,7 +138,7 @@ export default function DashboardPage() {
     }
   }
 
-  if (!ready) {
+  if (!authReady || !isAuthenticated) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-sky-50 via-white to-emerald-50/50 text-slate-500">
         Loading…

--- a/webapp/app/dashboard/page.tsx
+++ b/webapp/app/dashboard/page.tsx
@@ -88,8 +88,12 @@ export default function DashboardPage() {
     try {
       await postSearchHistory(token, {
         query,
-        minPriceCents: minPrice ? Math.round(Number(minPrice) * 100) : undefined,
-        maxPriceCents: maxPrice ? Math.round(Number(maxPrice) * 100) : undefined,
+        minPriceCents: minPrice
+          ? Math.round(Number(minPrice) * 100)
+          : undefined,
+        maxPriceCents: maxPrice
+          ? Math.round(Number(maxPrice) * 100)
+          : undefined,
         maxDistanceKm: maxKm ? Number(maxKm) : undefined,
       });
       setMsg("Search saved to history.");
@@ -138,12 +142,16 @@ export default function DashboardPage() {
     }
   }
 
-  if (!authReady || !isAuthenticated) {
+  if (!authReady) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-sky-50 via-white to-emerald-50/50 text-slate-500">
         Loading…
       </div>
     );
+  }
+
+  if (!isAuthenticated) {
+    return null;
   }
 
   return (
@@ -155,31 +163,50 @@ export default function DashboardPage() {
       <main className="mx-auto max-w-5xl px-4 py-10">
         <h1 className="font-serif text-3xl text-slate-900">Housing search</h1>
         <p className="mt-2 max-w-2xl text-sm text-slate-600">
-          Search preferences are stored as <strong className="text-slate-800">search history</strong> (booking-service).
-          Listings you care about go to your <strong className="text-slate-800">watchlist</strong> (UUIDs). Browse and post
-          listings on the{" "}
-          <a href="/listings" className="font-medium text-teal-700 hover:underline">
+          Search preferences are stored as{" "}
+          <strong className="text-slate-800">search history</strong>{" "}
+          (booking-service). Listings you care about go to your{" "}
+          <strong className="text-slate-800">watchlist</strong> (UUIDs). Browse
+          and post listings on the{" "}
+          <a
+            href="/listings"
+            className="font-medium text-teal-700 hover:underline"
+          >
             listings
           </a>{" "}
           page; trust tools on{" "}
-          <a href="/trust" className="font-medium text-teal-700 hover:underline">
+          <a
+            href="/trust"
+            className="font-medium text-teal-700 hover:underline"
+          >
             trust &amp; safety
           </a>
           . Map preview uses Google Maps Embed when{" "}
-          <code className="rounded bg-slate-200 px-1 text-xs text-slate-800">NEXT_PUBLIC_GOOGLE_MAPS_API_KEY</code> is set
-          (same as listings).
+          <code className="rounded bg-slate-200 px-1 text-xs text-slate-800">
+            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+          </code>{" "}
+          is set (same as listings).
         </p>
 
         <div className="mt-6 max-w-xl">
-          <GoogleMapEmbed placeQuery="University of Massachusetts Amherst" height={180} />
+          <GoogleMapEmbed
+            placeQuery="University of Massachusetts Amherst"
+            height={180}
+          />
         </div>
 
         <div className="mt-10 grid gap-10 lg:grid-cols-2">
           <section className="rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
             <h2 className="text-lg font-medium text-slate-900">Save search</h2>
-            <form data-testid="search-form" onSubmit={onSaveSearch} className="mt-4 space-y-3">
+            <form
+              data-testid="search-form"
+              onSubmit={onSaveSearch}
+              className="mt-4 space-y-3"
+            >
               <div>
-                <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Query</label>
+                <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  Query
+                </label>
                 <input
                   data-testid="search-query"
                   value={query}
@@ -189,7 +216,9 @@ export default function DashboardPage() {
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Min price (USD)</label>
+                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                    Min price (USD)
+                  </label>
                   <input
                     type="number"
                     step="0.01"
@@ -200,7 +229,9 @@ export default function DashboardPage() {
                   />
                 </div>
                 <div>
-                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Max price (USD)</label>
+                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                    Max price (USD)
+                  </label>
                   <input
                     type="number"
                     step="0.01"
@@ -212,7 +243,9 @@ export default function DashboardPage() {
                 </div>
               </div>
               <div>
-                <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Max distance (km)</label>
+                <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  Max distance (km)
+                </label>
                 <input
                   data-testid="search-max-km"
                   type="number"
@@ -235,8 +268,14 @@ export default function DashboardPage() {
 
           <section className="rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
             <h2 className="text-lg font-medium text-slate-900">Watchlist</h2>
-            <p className="mt-1 text-sm text-slate-600">Add a listing UUID (from listings or seed data).</p>
-            <form data-testid="watchlist-form" onSubmit={onAddWatch} className="mt-4 flex flex-col gap-2 sm:flex-row">
+            <p className="mt-1 text-sm text-slate-600">
+              Add a listing UUID (from listings or seed data).
+            </p>
+            <form
+              data-testid="watchlist-form"
+              onSubmit={onAddWatch}
+              className="mt-4 flex flex-col gap-2 sm:flex-row"
+            >
               <input
                 data-testid="watchlist-listing-id"
                 value={listingId}
@@ -254,7 +293,9 @@ export default function DashboardPage() {
               </button>
             </form>
             <ul data-testid="watchlist-items" className="mt-6 space-y-2">
-              {watchlist.length === 0 && <li className="text-sm text-slate-500">No items yet.</li>}
+              {watchlist.length === 0 && (
+                <li className="text-sm text-slate-500">No items yet.</li>
+              )}
               {watchlist.map((w) => (
                 <li
                   key={w.listingId}
@@ -277,7 +318,9 @@ export default function DashboardPage() {
 
         <section className="mt-10 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
           <div className="flex items-center justify-between gap-4">
-            <h2 className="text-lg font-medium text-slate-900">Search history</h2>
+            <h2 className="text-lg font-medium text-slate-900">
+              Search history
+            </h2>
             <button
               type="button"
               onClick={() => refreshAll()}
@@ -306,17 +349,26 @@ export default function DashboardPage() {
                   </tr>
                 )}
                 {history.map((row) => (
-                  <tr key={row.id ?? `${row.query}-${row.createdAt}`} className="border-b border-slate-100">
+                  <tr
+                    key={row.id ?? `${row.query}-${row.createdAt}`}
+                    className="border-b border-slate-100"
+                  >
                     <td className="py-2 pr-4">{row.query ?? "—"}</td>
                     <td className="py-2 pr-4">
-                      {row.minPriceCents != null ? (row.minPriceCents / 100).toFixed(2) : "—"}
+                      {row.minPriceCents != null
+                        ? (row.minPriceCents / 100).toFixed(2)
+                        : "—"}
                     </td>
                     <td className="py-2 pr-4">
-                      {row.maxPriceCents != null ? (row.maxPriceCents / 100).toFixed(2) : "—"}
+                      {row.maxPriceCents != null
+                        ? (row.maxPriceCents / 100).toFixed(2)
+                        : "—"}
                     </td>
                     <td className="py-2 pr-4">{row.maxDistanceKm ?? "—"}</td>
                     <td className="py-2 text-slate-500">
-                      {row.createdAt ? new Date(row.createdAt).toLocaleString() : "—"}
+                      {row.createdAt
+                        ? new Date(row.createdAt).toLocaleString()
+                        : "—"}
                     </td>
                   </tr>
                 ))}
@@ -325,7 +377,11 @@ export default function DashboardPage() {
           </div>
           {(() => {
             const withGeo = history.find(
-              (r) => r.latitude != null && r.longitude != null && Number.isFinite(r.latitude) && Number.isFinite(r.longitude)
+              (r) =>
+                r.latitude != null &&
+                r.longitude != null &&
+                Number.isFinite(r.latitude) &&
+                Number.isFinite(r.longitude),
             );
             if (!withGeo) return null;
             return (
@@ -333,13 +389,20 @@ export default function DashboardPage() {
                 <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
                   Latest search with location
                 </p>
-                <GoogleMapEmbed latitude={withGeo.latitude} longitude={withGeo.longitude} height={200} zoom={13} />
+                <GoogleMapEmbed
+                  latitude={withGeo.latitude}
+                  longitude={withGeo.longitude}
+                  height={200}
+                  zoom={13}
+                />
               </div>
             );
           })()}
         </section>
 
-        {msg && <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>}
+        {msg && (
+          <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>
+        )}
         {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
       </main>
     </div>

--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { AuthProvider } from "@/lib/auth-context";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -25,7 +26,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased font-sans`}>{children}</body>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased font-sans`}
+      >
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/webapp/app/login/page.tsx
+++ b/webapp/app/login/page.tsx
@@ -4,11 +4,12 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { loginUser } from "@/lib/api";
-import { setStoredEmail, setStoredToken } from "@/lib/auth-storage";
 import { Nav } from "@/components/Nav";
+import { useAuth } from "@/lib/auth-context";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -21,8 +22,7 @@ export default function LoginPage() {
     try {
       const data = await loginUser(email, password);
       if (!data.token) throw new Error("No token returned");
-      setStoredToken(data.token);
-      setStoredEmail(email.trim());
+      login(data.token, email);
       router.push("/dashboard");
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : "Login failed");

--- a/webapp/app/register/page.tsx
+++ b/webapp/app/register/page.tsx
@@ -4,11 +4,12 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { registerUser } from "@/lib/api";
-import { setStoredEmail, setStoredToken } from "@/lib/auth-storage";
 import { Nav } from "@/components/Nav";
+import { useAuth } from "@/lib/auth-context";
 
 export default function RegisterPage() {
   const router = useRouter();
+  const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -21,8 +22,7 @@ export default function RegisterPage() {
     try {
       const data = await registerUser(email, password);
       if (!data.token) throw new Error("No token returned");
-      setStoredToken(data.token);
-      setStoredEmail(email.trim());
+      login(data.token, email);
       router.push("/dashboard");
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : "Registration failed");

--- a/webapp/components/Nav.tsx
+++ b/webapp/components/Nav.tsx
@@ -27,7 +27,10 @@ export function Nav({ email }: { email?: string | null }) {
           </Link>
           {email ? (
             <>
-              <span className="hidden max-w-[200px] truncate text-slate-500 sm:inline" title={email ?? ""}>
+              <span
+                className="hidden max-w-[200px] truncate text-slate-500 sm:inline"
+                title={email ?? ""}
+              >
                 {email}
               </span>
               <Link href="/dashboard" className="hover:text-teal-700">
@@ -39,6 +42,12 @@ export function Nav({ email }: { email?: string | null }) {
                 className="rounded-md border border-slate-300 px-2 py-1.5 text-slate-700 hover:bg-slate-50"
                 onClick={() => {
                   clearStoredToken();
+
+                  if (typeof window !== "undefined") {
+                    window.location.assign("/login");
+                    return;
+                  }
+
                   router.push("/login");
                   router.refresh();
                 }}

--- a/webapp/components/Nav.tsx
+++ b/webapp/components/Nav.tsx
@@ -2,10 +2,12 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { clearStoredToken } from "@/lib/auth-storage";
+import { useAuth } from "@/lib/auth-context";
 
 export function Nav({ email }: { email?: string | null }) {
   const router = useRouter();
+  const { logout } = useAuth();
+
   return (
     <header className="border-b border-teal-200/60 bg-white/80 backdrop-blur-md">
       <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-4 py-4">
@@ -41,13 +43,7 @@ export function Nav({ email }: { email?: string | null }) {
                 data-testid="nav-sign-out"
                 className="rounded-md border border-slate-300 px-2 py-1.5 text-slate-700 hover:bg-slate-50"
                 onClick={() => {
-                  clearStoredToken();
-
-                  if (typeof window !== "undefined") {
-                    window.location.assign("/login");
-                    return;
-                  }
-
+                  logout();
                   router.push("/login");
                   router.refresh();
                 }}

--- a/webapp/lib/auth-context.tsx
+++ b/webapp/lib/auth-context.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  clearStoredToken,
+  getStoredEmail,
+  getStoredToken,
+  setStoredEmail,
+  setStoredToken,
+} from "@/lib/auth-storage";
+
+type AuthContextValue = {
+  authReady: boolean;
+  token: string | null;
+  email: string | null;
+  isAuthenticated: boolean;
+  login: (token: string, email: string) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [authReady, setAuthReady] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedToken = getStoredToken();
+    const storedEmail = getStoredEmail();
+
+    setToken(storedToken);
+    setEmail(storedEmail);
+    setAuthReady(true);
+  }, []);
+
+  const login = useCallback((nextToken: string, nextEmail: string) => {
+    const normalizedEmail = nextEmail.trim();
+    setStoredToken(nextToken);
+    setStoredEmail(normalizedEmail);
+    setToken(nextToken);
+    setEmail(normalizedEmail);
+  }, []);
+
+  const logout = useCallback(() => {
+    clearStoredToken();
+    setToken(null);
+    setEmail(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      authReady,
+      token,
+      email,
+      isAuthenticated: Boolean(token),
+      login,
+      logout,
+    }),
+    [authReady, token, email, login, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const value = useContext(AuthContext);
+  if (!value) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return value;
+}


### PR DESCRIPTION
## What this PR does

Fixes root cause of auth session instability and redirect issues.

- Introduces shared auth context with hydration (`authReady`)
- Removes reliance on hard redirects (`window.location`)
- Restores SPA navigation using `router.push`
- Ensures dashboard waits for auth state before redirecting

## Fixes

- Closes #42
- Closes #44

## Why

Previously:
- Navigation happened before auth state was ready
- Caused race conditions and redirect loops
- A temporary workaround used hard redirects

Now:
- Auth state is initialized before protected routes render
- Navigation is state-driven instead of storage-timing dependent

## Manual testing

- Login redirects to `/dashboard`
- Register redirects to `/dashboard`
- Refreshing `/dashboard` preserves session
- Logout sends user to `/login`
- Logged-out access to `/dashboard` redirects correctly