### PR TITLE
test(webapp): improve Playwright failure diagnostics

### DIFF
--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -66,26 +66,26 @@ const suiteProjects = [
 export default defineConfig({
   globalSetup: "./playwright.global-setup.ts",
   testDir: "./e2e",
-  /** Register + edge round-trips exceed 30s under load; keep auth/listings verticals reliable. */
   timeout: 120_000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  /**
-   * Fixed 4 workers: load is shaped by gateway (E2E shaper + X-Test-Mode inflight cap) and serial
-   * heavy Playwright files — not by starving parallelism.
-   */
   workers: 4,
-  reporter: [["list"], ["html", { open: "never" }]],
+  outputDir: "test-results",
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report" }],
+  ],
   use: {
     baseURL,
-    // Browser E2E runs against local dev certs; app behavior is under test, not certificate validation.
     ignoreHTTPSErrors: true,
     extraHTTPHeaders: {
       "x-e2e-test": "1",
       "x-test-mode": "1",
     },
     trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: suiteProjects.map((p) => ({
     name: p.name,

--- a/webapp/playwright.global-setup.ts
+++ b/webapp/playwright.global-setup.ts
@@ -13,15 +13,19 @@ export default async function globalSetup(): Promise<void> {
   const raw = process.env.E2E_API_BASE?.trim() || "https://off-campus-housing.test";
   const base = raw.replace(/\/$/, "");
   const caPath = process.env.NODE_EXTRA_CA_CERTS?.trim();
+
+  console.log(`[playwright global setup] strict edge check enabled for ${base}`);
+
   if (!caPath || !fs.existsSync(caPath)) {
     throw new Error(
       "PLAYWRIGHT_VERTICAL_STRICT=1 requires NODE_EXTRA_CA_CERTS pointing to an existing CA file",
     );
   }
-  const ca = fs.readFileSync(caPath);
 
+  const ca = fs.readFileSync(caPath);
   const url = new URL(`${base}/api/healthz`);
   const port = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
+
   if (url.protocol !== "https:") {
     throw new Error(`PLAYWRIGHT_VERTICAL_STRICT requires https E2E_API_BASE, got ${url.protocol}`);
   }
@@ -40,17 +44,23 @@ export default async function globalSetup(): Promise<void> {
       (res) => {
         res.resume();
         if (res.statusCode === 200) {
+          console.log(`[playwright global setup] edge health check passed: ${url.toString()}`);
           resolve();
         } else {
           reject(new Error(`edge /api/healthz returned ${res.statusCode}`));
         }
       },
     );
-    req.on("error", reject);
+
+    req.on("error", (err) => {
+      reject(new Error(`[playwright global setup] edge check failed: ${String(err)}`));
+    });
+
     req.on("timeout", () => {
       req.destroy();
       reject(new Error("edge /api/healthz TLS request timed out"));
     });
+
     req.end();
   });
 }


### PR DESCRIPTION
## What this PR does

Improves Playwright debugging output for failing E2E tests.

- Adds screenshots on failure
- Retains video on failure
- Keeps trace on first retry
- Sets predictable artifact directories
- Improves strict global setup logging for edge health checks

## Fixes

- Closes #43

## Why

Failing E2E tests should provide actionable artifacts and logs so failures can be reproduced and debugged quickly both locally and in CI.