### PR TITLE
test(media-service): verify persisted upload metadata

### DIFF
--- a/services/media-service/tests/integration/media-upload.integration.test.ts
+++ b/services/media-service/tests/integration/media-upload.integration.test.ts
@@ -20,22 +20,36 @@ describe('Media upload (integration)', () => {
     }
   })
 
-  it('B) createUploadUrl then completeUpload sets DB status to uploaded', async () => {
+  it('B) createUploadUrl then completeUpload persists metadata and sets DB status to uploaded', async () => {
     const userId = '11111111-1111-4111-a111-111111111111'
+    const filename = 'test.png'
+    const contentType = 'image/png'
+    const sizeBytes = 100
+
     const { mediaId } = await createUploadUrl({
       userId,
-      filename: 'test.png',
-      contentType: 'image/png',
-      sizeBytes: 100,
+      filename,
+      contentType,
+      sizeBytes,
     })
     expect(mediaId).toBeDefined()
 
     try {
+      const pendingRow = await getById(mediaId)
+      expect(pendingRow).not.toBeNull()
+      expect(pendingRow!.filename).toBe(filename)
+      expect(pendingRow!.content_type).toBe(contentType)
+      expect(pendingRow!.size_bytes).toBe(sizeBytes)
+      expect(pendingRow!.status).toBe('pending')
+
       const completed = await completeUpload(mediaId)
       expect(completed).toBe(true)
 
       const row = await getById(mediaId)
       expect(row).not.toBeNull()
+      expect(row!.filename).toBe(filename)
+      expect(row!.content_type).toBe(contentType)
+      expect(row!.size_bytes).toBe(sizeBytes)
       expect(row!.status).toBe('uploaded')
 
       const hasOutbox = await pool.query(


### PR DESCRIPTION
## Summary

Adds integration coverage to verify that media upload metadata is correctly persisted in `media.media_files`.

## Why

Metadata persistence was already implemented, but not explicitly validated in integration tests. This adds regression coverage for:

- `filename`
- `content_type`
- `size_bytes`

## Changes

- Added assertions after `createUploadUrl(...)` to verify metadata is stored in the pending row
- Added assertions after `completeUpload(...)` to verify metadata persists after upload completion
- Kept existing outbox event validation intact

## Scope

- `services/media-service/tests/integration/media-upload.integration.test.ts` only
- No production code changes

## Verification

- Ran `pnpm --filter media-service test`
- Confirmed metadata fields match input values
- Confirmed status transitions (`pending` → `uploaded`)

Closes #25 