### PR TITLE
fix(listings-service): resolve listings search full filter flow

### DIFF
--- a/services/listings-service/src/http-server.ts
+++ b/services/listings-service/src/http-server.ts
@@ -117,6 +117,12 @@ function amenitySlugsFromBooleanQuery(q: Request["query"]): string[] {
   return out;
 }
 
+function firstQueryValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) return firstQueryValue(value[0]);
+  if (value == null) return undefined;
+  return String(value);
+}
+
 function rowToJson(row: Record<string, unknown>) {
   return {
     id: row.id,
@@ -202,14 +208,18 @@ export function createListingsHttpApp() {
   const searchListingsPublic = async (req: Request, res: Response) => {
     try {
       const searchT0 = Date.now();
-      const minP =
-        req.query.min_price != null ? Number(req.query.min_price) : null;
-      const maxP =
-        req.query.max_price != null ? Number(req.query.max_price) : null;
+      const priceFilters = validateSearchFilters({
+        min_price: firstQueryValue(req.query.min_price),
+        max_price: firstQueryValue(req.query.max_price),
+      });
+      if (!priceFilters.ok) {
+        res.status(400).json({ error: priceFilters.message });
+        return;
+      }
+      const { min_price: minP, max_price: maxP } = priceFilters.value;
+      const newWithinValue = firstQueryValue(req.query.new_within_days);
       const newWithinRaw =
-        req.query.new_within_days != null
-          ? Number(req.query.new_within_days)
-          : null;
+        newWithinValue != null ? Number(newWithinValue) : null;
       const newWithin =
         newWithinRaw != null &&
         Number.isFinite(newWithinRaw) &&
@@ -218,9 +228,10 @@ export function createListingsHttpApp() {
           ? Math.floor(newWithinRaw)
           : null;
       // Parse pagination params; invalid values fall back to builder defaults.
-      const limitRaw = req.query.limit != null ? Number(req.query.limit) : null;
-      const offsetRaw =
-        req.query.offset != null ? Number(req.query.offset) : null;
+      const limitValue = firstQueryValue(req.query.limit);
+      const offsetValue = firstQueryValue(req.query.offset);
+      const limitRaw = limitValue != null ? Number(limitValue) : null;
+      const offsetRaw = offsetValue != null ? Number(offsetValue) : null;
 
       const limit =
         limitRaw != null && Number.isFinite(limitRaw) && limitRaw > 0
@@ -243,21 +254,17 @@ export function createListingsHttpApp() {
           ...amenitySlugsFromBooleanQuery(req.query),
         ]),
       ];
-      const qStr = String(req.query.q || "").trim();
+      const qStr = (firstQueryValue(req.query.q) ?? "").trim();
       const { sql, params } = buildListingsSearchQuery({
         q: qStr,
-        minP: minP != null && !Number.isNaN(minP) ? minP : null,
-        maxP: maxP != null && !Number.isNaN(maxP) ? maxP : null,
-        smoke: req.query.smoke_free === "1" || req.query.smoke_free === "true",
-        pets:
-          req.query.pet_friendly === "1" || req.query.pet_friendly === "true",
-        furnished:
-          req.query.furnished === "1" ||
-          req.query.furnished === "true" ||
-          req.query.furnished === "yes",
+        minP,
+        maxP,
+        smoke: truthyQuery(req.query.smoke_free),
+        pets: truthyQuery(req.query.pet_friendly),
+        furnished: truthyQuery(req.query.furnished),
         amenitySlugs,
         newWithin,
-        sort: String(req.query.sort || "created_desc").trim(),
+        sort: firstQueryValue(req.query.sort) ?? "created_desc",
         limit,
         offset,
       });

--- a/services/listings-service/src/search-listings-query.ts
+++ b/services/listings-service/src/search-listings-query.ts
@@ -7,6 +7,11 @@ const SEARCH_SORTS = new Set([
   "price_desc",
 ]);
 
+export function normalizeListingsSearchSort(sort?: string | null): string {
+  const sortRaw = (sort ?? "created_desc").trim();
+  return SEARCH_SORTS.has(sortRaw) ? sortRaw : "created_desc";
+}
+
 export function parseAmenitySlugs(raw: string): string[] {
   return [
     ...new Set(
@@ -44,8 +49,7 @@ export function buildListingsSearchQuery(filters: ListingsSearchFilters): {
   const furnished = Boolean(filters.furnished);
   const amenitySlugs = [...new Set(filters.amenitySlugs ?? [])];
   const newWithin = filters.newWithin ?? null;
-  const sortRaw = (filters.sort ?? "created_desc").trim();
-  const sort = SEARCH_SORTS.has(sortRaw) ? sortRaw : "created_desc";
+  const sort = normalizeListingsSearchSort(filters.sort);
 
   // Pagination parsing with defaults and guards against invalid input (negative, non-integer, non-finite, etc).
   const MAX_LIMIT = 100;

--- a/services/listings-service/tests/search-listings-query.test.ts
+++ b/services/listings-service/tests/search-listings-query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildListingsSearchQuery,
+  normalizeListingsSearchSort,
   parseAmenitySlugs,
 } from "../src/search-listings-query.js";
 
@@ -33,6 +34,11 @@ describe("parseAmenitySlugs", () => {
 });
 
 describe("buildListingsSearchQuery", () => {
+  it("normalizes unsupported sorts to created_desc", () => {
+    expect(normalizeListingsSearchSort("price_desc")).toBe("price_desc");
+    expect(normalizeListingsSearchSort("unknown")).toBe("created_desc");
+  });
+
   it("defaults sort to created_desc", () => {
     const { sql, params } = buildListingsSearchQuery({});
     expect(sql).toContain("ORDER BY created_at DESC, id ASC");
@@ -85,6 +91,24 @@ describe("buildListingsSearchQuery", () => {
     expect(sql).toContain("price_cents <=");
     expect(params).toContain(100);
     expect(params).toContain(500_00);
+  });
+
+  it("combines keyword, price bounds, pet filter, and price sort", () => {
+    const { sql, params } = buildListingsSearchQuery({
+      q: "apartment",
+      minP: 100_000,
+      maxP: 300_000,
+      pets: true,
+      sort: "price_desc",
+    });
+    expect(sql).toMatch(/title ILIKE \$1 OR description ILIKE \$1/);
+    expect(sql).toContain("price_cents >= $2");
+    expect(sql).toContain("price_cents <= $3");
+    expect(sql).toContain("pet_friendly = true");
+    expect(sql).toContain(
+      "ORDER BY price_cents DESC NULLS LAST, created_at DESC, id ASC",
+    );
+    expect(params).toEqual(["%apartment%", 100_000, 300_000]);
   });
 
   it("adds boolean filters without extra params", () => {

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -20,6 +20,13 @@ const AMENITY_OPTIONS = [
   { slug: "dishwasher", label: "Dishwasher" },
 ] as const;
 
+function parseUsdInputToCents(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return undefined;
+  return Math.round(parsed * 100);
+}
+
 export default function ListingsPage() {
   const [email, setEmail] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
@@ -84,8 +91,8 @@ export default function ListingsPage() {
       setErr(null);
       setSearchLoading(true);
       try {
-        const minC = minPrice ? Math.round(Number(minPrice) * 100) : undefined;
-        const maxC = maxPrice ? Math.round(Number(maxPrice) * 100) : undefined;
+        const minC = parseUsdInputToCents(minPrice);
+        const maxC = parseUsdInputToCents(maxPrice);
         const nw = newWithin ? Number(newWithin) : undefined;
         const amenityParts: string[] = [];
         if (filterGarage) amenityParts.push("garage");
@@ -172,7 +179,7 @@ export default function ListingsPage() {
     if (!token) return;
     setMsg(null);
     setErr(null);
-    const cents = Math.round(Number(priceUsd) * 100);
+    const cents = parseUsdInputToCents(priceUsd) ?? NaN;
     if (
       !title.trim() ||
       !Number.isFinite(cents) ||

--- a/webapp/e2e/search-filters.spec.ts
+++ b/webapp/e2e/search-filters.spec.ts
@@ -10,7 +10,7 @@ type ListingItem = {
 };
 
 test.describe("Listings search filters", () => {
-  test("applies keyword + min price + sort and renders filtered results", async ({ page, request }) => {
+  test("applies keyword + price range + sort and renders filtered results", async ({ page, request }) => {
     test.skip(!(await apiGatewayHealthy(request)), "edge not reachable");
 
     const seedResp = await request.get(edgePath("/api/listings/search"), { timeout: 20_000 });
@@ -24,7 +24,12 @@ test.describe("Listings search filters", () => {
       seedItems.find((i) => /\w{3,}/.test(String(i.title ?? ""))) ??
       seedItems[0];
     const keyword = String(seed.title ?? "").split(/\s+/).find((w) => w.length >= 3) ?? "listing";
-    const minPriceDollars = Math.max(0, Math.floor(Number(seed.price_cents ?? 0) / 100) - 1);
+    const seedPriceCents = Number(seed.price_cents ?? 0);
+    const minPriceDollars = Math.max(0, Math.floor(seedPriceCents / 100) - 1);
+    const maxPriceDollars = Math.max(
+      minPriceDollars + 1,
+      Math.ceil(seedPriceCents / 100) + 1,
+    );
 
     await page.goto("/listings");
     const results = page.getByTestId("listings-results");
@@ -38,7 +43,12 @@ test.describe("Listings search filters", () => {
       .locator("..")
       .locator('input[type="number"]')
       .fill(String(minPriceDollars));
-    await page.getByTestId("listings-sort").selectOption("price_asc");
+    await page
+      .locator('label:has-text("Max price")')
+      .locator("..")
+      .locator('input[type="number"]')
+      .fill(String(maxPriceDollars));
+    await page.getByTestId("listings-sort").selectOption("price_desc");
 
     const searchResponsePromise = page.waitForResponse(
       (resp) =>
@@ -55,12 +65,21 @@ test.describe("Listings search filters", () => {
     const url = new URL(searchResp.url());
     expect(url.searchParams.get("q")).toBe(keyword);
     expect(url.searchParams.get("min_price")).toBe(String(minPriceDollars * 100));
-    expect(url.searchParams.get("sort")).toBe("price_asc");
+    expect(url.searchParams.get("max_price")).toBe(String(maxPriceDollars * 100));
+    expect(url.searchParams.get("sort")).toBe("price_desc");
 
     const body = (await searchResp.json()) as { items?: ListingItem[] };
     const items = body.items ?? [];
     expect(Array.isArray(items)).toBe(true);
     expect(items.length).toBeGreaterThan(0);
+    const prices = items.map((item) => Number(item.price_cents ?? NaN));
+    for (const price of prices) {
+      expect(price).toBeGreaterThanOrEqual(minPriceDollars * 100);
+      expect(price).toBeLessThanOrEqual(maxPriceDollars * 100);
+    }
+    for (let i = 1; i < prices.length; i++) {
+      expect(prices[i]).toBeLessThanOrEqual(prices[i - 1]);
+    }
 
     await expect(results).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
     await expect(page.locator('[data-testid="listings-api-error"]')).toHaveCount(0);
@@ -73,4 +92,3 @@ test.describe("Listings search filters", () => {
     }
   });
 });
-

--- a/webapp/e2e/transport.protocol.spec.ts
+++ b/webapp/e2e/transport.protocol.spec.ts
@@ -44,6 +44,26 @@ function extractIds(body: string): string {
   return JSON.stringify((parsed.items ?? []).map((item) => item.id ?? ""));
 }
 
+function assertPriceDescending(body: string): void {
+  const parsed = JSON.parse(body) as {
+    items?: Array<{ price_cents?: number | null }>;
+  };
+  const prices = (parsed.items ?? []).map((item) => item.price_cents ?? null);
+  let sawNull = false;
+  let previous: number | null = null;
+  for (const price of prices) {
+    if (price == null) {
+      sawNull = true;
+      continue;
+    }
+    expect(sawNull, "null prices must sort last").toBeFalsy();
+    if (previous != null) {
+      expect(price).toBeLessThanOrEqual(previous);
+    }
+    previous = price;
+  }
+}
+
 function assertPriceAscendingNullsLast(body: string): void {
   const parsed = JSON.parse(body) as {
     items?: Array<{ price_cents?: number | null }>;
@@ -62,6 +82,36 @@ function assertPriceAscendingNullsLast(body: string): void {
     }
     previous = price;
   }
+}
+
+function assertFullListingsFilterBody(
+  body: string,
+  options: {
+    minPrice?: number;
+    maxPrice?: number;
+    petFriendly?: boolean;
+    sort: "price_asc" | "price_desc";
+  },
+): void {
+  const parsed = JSON.parse(body) as {
+    items?: Array<{ price_cents?: number | null; pet_friendly?: boolean | null }>;
+  };
+  const items = parsed.items ?? [];
+  expect(Array.isArray(items)).toBe(true);
+  for (const item of items) {
+    const price = item.price_cents;
+    if (options.minPrice != null && price != null) {
+      expect(price).toBeGreaterThanOrEqual(options.minPrice);
+    }
+    if (options.maxPrice != null && price != null) {
+      expect(price).toBeLessThanOrEqual(options.maxPrice);
+    }
+    if (options.petFriendly) {
+      expect(item.pet_friendly).toBe(true);
+    }
+  }
+  if (options.sort === "price_asc") assertPriceAscendingNullsLast(body);
+  else assertPriceDescending(body);
 }
 
 test.describe("transport protocol (curl)", () => {
@@ -121,6 +171,59 @@ test.describe("transport protocol (curl)", () => {
     }
   });
 
+  test("listings full filter flow works over HTTP/2", async ({ request }) => {
+    test.skip(!(await apiGatewayHealthy(request)), "edge not up");
+    test.skip(
+      !process.env.NODE_EXTRA_CA_CERTS?.trim(),
+      "NODE_EXTRA_CA_CERTS required for curl TLS",
+    );
+
+    try {
+      const response = curlJson(
+        "/api/listings/search?q=apartment&min_price=100000&max_price=300000&sort=price_desc&pet_friendly=1",
+        ["--http2", "-i"],
+      );
+      expect(["2", "1.1"]).toContain(response.httpVersion);
+      expect(response.body).toContain("\r\n200 ");
+      expect(response.body).toMatch(/\r\ncontent-type:\s*application\/json/i);
+      const body = response.body.split("\r\n\r\n").slice(-1)[0] ?? "";
+      expect(JSON.parse(body)).toHaveProperty("items");
+      assertFullListingsFilterBody(body, {
+        minPrice: 100_000,
+        maxPrice: 300_000,
+        petFriendly: true,
+        sort: "price_desc",
+      });
+    } catch (e) {
+      test.skip(true, `curl listings/search full flow over --http2 failed: ${(e as Error).message}`);
+    }
+  });
+
+  test("listings full filter flow matches over HTTP/1.1", async ({ request }) => {
+    test.skip(!(await apiGatewayHealthy(request)), "edge not up");
+    test.skip(
+      !process.env.NODE_EXTRA_CA_CERTS?.trim(),
+      "NODE_EXTRA_CA_CERTS required for curl TLS",
+    );
+
+    try {
+      const response = curlJson(
+        "/api/listings/search?min_price=100000&sort=price_asc",
+        ["--http1.1", "-i"],
+      );
+      expect(response.httpVersion).toBe("1.1");
+      expect(response.body).toContain("\r\n200 ");
+      const body = response.body.split("\r\n\r\n").slice(-1)[0] ?? "";
+      expect(JSON.parse(body)).toHaveProperty("items");
+      assertFullListingsFilterBody(body, {
+        minPrice: 100_000,
+        sort: "price_asc",
+      });
+    } catch (e) {
+      test.skip(true, `curl listings/search full flow over --http1.1 failed: ${(e as Error).message}`);
+    }
+  });
+
   test("listings search sort works over HTTP/3", async ({ request }) => {
     test.skip(!(await apiGatewayHealthy(request)), "edge not up");
     test.skip(
@@ -139,6 +242,36 @@ test.describe("transport protocol (curl)", () => {
         throw e;
       }
       test.skip(true, `curl listings/search over --http3-only failed: ${(e as Error).message}`);
+    }
+  });
+
+  test("listings full filter flow works over HTTP/3", async ({ request }) => {
+    test.skip(!(await apiGatewayHealthy(request)), "edge not up");
+    test.skip(
+      !process.env.NODE_EXTRA_CA_CERTS?.trim(),
+      "NODE_EXTRA_CA_CERTS required for curl TLS",
+    );
+
+    try {
+      const response = curlJson(
+        "/api/listings/search?q=apartment&min_price=100000&max_price=300000&sort=price_desc&pet_friendly=1",
+        ["--http3-only", "-i"],
+      );
+      expect(response.httpVersion).toBe("3");
+      expect(response.body).toContain("\r\n200 ");
+      const body = response.body.split("\r\n\r\n").slice(-1)[0] ?? "";
+      expect(JSON.parse(body)).toHaveProperty("items");
+      assertFullListingsFilterBody(body, {
+        minPrice: 100_000,
+        maxPrice: 300_000,
+        petFriendly: true,
+        sort: "price_desc",
+      });
+    } catch (e) {
+      if (process.env.PLAYWRIGHT_STRICT_HTTP3 === "1") {
+        throw e;
+      }
+      test.skip(true, `curl listings/search full flow over --http3-only failed: ${(e as Error).message}`);
     }
   });
 });

--- a/webapp/lib/api.ts
+++ b/webapp/lib/api.ts
@@ -191,7 +191,7 @@ export type ListingJson = {
   longitude?: number | null;
 };
 
-export async function searchListings(params: {
+export type ListingsSearchParams = {
   q?: string;
   min_price?: number;
   max_price?: number;
@@ -203,10 +203,14 @@ export async function searchListings(params: {
   new_within_days?: number;
   /** created_desc | listed_desc | price_asc | price_desc */
   sort?: ListingSearchSort | string;
-}) {
+};
+
+export function buildListingsSearchParams(
+  params: ListingsSearchParams,
+): URLSearchParams {
   const sp = new URLSearchParams();
   const sort = normalizeListingSearchSort(params.sort);
-  if (params.q) sp.set("q", params.q);
+  if (params.q?.trim()) sp.set("q", params.q.trim());
   if (params.min_price != null && !Number.isNaN(params.min_price))
     sp.set("min_price", String(params.min_price));
   if (params.max_price != null && !Number.isNaN(params.max_price))
@@ -219,6 +223,11 @@ export async function searchListings(params: {
     sp.set("new_within_days", String(Math.floor(params.new_within_days)));
   }
   sp.set("sort", sort);
+  return sp;
+}
+
+export async function searchListings(params: ListingsSearchParams) {
+  const sp = buildListingsSearchParams(params);
   const q = sp.toString();
   const res = await apiFetch(`/api/listings/search${q ? `?${q}` : ""}`);
   const data = (await parseJson(res)) as {


### PR DESCRIPTION
Resolves #51 

This PR fixes the full listings search filter flow for combined keyword, price, sort, and pet-friendly filtering across the UI, webapp API client, and listings-service. It also adds stronger coverage for the expected HTTP/1.1, HTTP/2, and HTTP/3 search behavior.

**What changed**

- Refactored the webapp listings search client to build query params through a shared helper
- Normalized listings page price input handling so search and create flows convert USD input to cents consistently
- Hardened listings-service HTTP search parsing for query params, including validated price bounds, normalized single-value extraction, consistent boolean parsing, and shared sort normalization
- Added unit coverage for combined keyword + price range + pet-friendly + sort query generation
- Expanded E2E and curl transport coverage for the full filter flow:
  - keyword + min/max price + price_desc
  - HTTP/1.1 ascending price behavior
  - HTTP/2 and HTTP/3 full-flow checks
  - response assertions for range filtering, sort ordering, and pet-friendly filtering