### PR TITLE
fix(webapp): restore search history save flow across gateway, booking service, and dashboard

### DIFF
--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -106,6 +106,14 @@ function injectIdentityHeadersIfAny(req: AuthedRequest, _res: Response, next: Ne
   next();
 }
 
+function disableHistoryCaching(_req: Request, res: Response, next: NextFunction) {
+  res.setHeader("Cache-Control", "private, no-store, max-age=0");
+  res.setHeader("Pragma", "no-cache");
+  res.setHeader("Expires", "0");
+  res.vary("Authorization");
+  next();
+}
+
 const grpcStatusToHttp: Record<number, number> = {
   [grpc.status.INVALID_ARGUMENT ?? 3]: 400,
   [grpc.status.UNAUTHENTICATED ?? 16]: 401,
@@ -510,6 +518,16 @@ app.post("/auth/validate", jsonParser, validateTokenHandler);
 app.post("/api/auth/validate", jsonParser, validateTokenHandler);
 app.post("/auth/refresh", jsonParser, refreshTokenHandler);
 app.post("/api/auth/refresh", jsonParser, refreshTokenHandler);
+
+app.use(
+  [
+    "/booking/search-history",
+    "/booking/search-history/list",
+    "/api/booking/search-history",
+    "/api/booking/search-history/list",
+  ],
+  disableHistoryCaching,
+);
 
 // Unknown /api/* (no mounted service prefix) → 404 without JWT (avoids 401 on typos / missing routes).
 const KNOWN_API_FIRST_SEGMENTS = new Set([

--- a/services/booking-service/src/http-app.ts
+++ b/services/booking-service/src/http-app.ts
@@ -69,6 +69,13 @@ const TENANT_NOTES_MAX = 4000;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function disableHistoryCaching(res: Response): void {
+  res.setHeader("Cache-Control", "private, no-store, max-age=0");
+  res.setHeader("Pragma", "no-cache");
+  res.setHeader("Expires", "0");
+  res.vary("x-user-id");
+}
+
 export function createBookingHttpApp(): Express {
   const app = express();
   app.use(express.json({ limit: "1mb" }));
@@ -236,6 +243,7 @@ export function createBookingHttpApp(): Express {
 
   app.post("/search-history", requireUser, async (req: AuthedRequest, res: Response) => {
     try {
+      disableHistoryCaching(res);
       const { query, minPriceCents, maxPriceCents, maxDistanceKm, latitude, longitude, filters } = req.body as {
         query?: string;
         minPriceCents?: number;
@@ -266,6 +274,7 @@ export function createBookingHttpApp(): Express {
 
   app.get("/search-history/list", requireUser, async (req: AuthedRequest, res: Response) => {
     try {
+      disableHistoryCaching(res);
       const limit = Math.min(Number(req.query.limit || 25), 100);
       const items = await prisma.searchHistory.findMany({
         where: { userId: req.userId! },

--- a/services/booking-service/src/server.ts
+++ b/services/booking-service/src/server.ts
@@ -13,6 +13,7 @@ async function main() {
     requiredTopics: [BOOKING_EVENTS_TOPIC, userLifecycleV1Topic()],
   });
   const app = createBookingHttpApp();
+  app.set("etag", false);
   app.listen(HTTP_PORT, "0.0.0.0", () => {
     console.log(`[booking] HTTP server listening on port ${HTTP_PORT}`);
   });

--- a/services/booking-service/tests/booking-http.integration.test.ts
+++ b/services/booking-service/tests/booking-http.integration.test.ts
@@ -114,9 +114,13 @@ describe.skipIf(skip || !dbReady)("booking HTTP — full surface", () => {
       .send({ query: q, maxDistanceKm: 3 });
     expect(post.status, post.text).toBe(201);
     expect(post.body.query).toBe(q);
+    expect(post.headers["cache-control"]).toContain("no-store");
+    expect(post.headers["pragma"]).toBe("no-cache");
 
     const list = await request(app).get("/search-history/list").set("x-user-id", tenantId);
     expect(list.status, list.text).toBe(200);
+    expect(list.headers["cache-control"]).toContain("no-store");
+    expect(list.headers["pragma"]).toBe("no-cache");
     const items = list.body.items as { query?: string }[];
     expect(Array.isArray(items)).toBe(true);
     expect(items.some((r) => r.query === q)).toBe(true);

--- a/webapp/app/dashboard/page.tsx
+++ b/webapp/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import {
   listSearchHistory,
   postSearchHistory,
+  type SearchHistoryRow,
   watchlistAdd,
   watchlistList,
   watchlistRemove,
@@ -13,16 +14,7 @@ import { useAuth } from "@/lib/auth-context";
 import { Nav } from "@/components/Nav";
 import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
 
-type SearchRow = {
-  id?: string;
-  query?: string | null;
-  minPriceCents?: number | null;
-  maxPriceCents?: number | null;
-  maxDistanceKm?: number | null;
-  latitude?: number | null;
-  longitude?: number | null;
-  createdAt?: string;
-};
+type SearchRow = SearchHistoryRow;
 
 type WatchRow = {
   listingId?: string;
@@ -85,17 +77,21 @@ export default function DashboardPage() {
     setMsg(null);
     setErr(null);
     setLoading(true);
+    const nextRow: SearchRow = {
+      query,
+      minPriceCents: minPrice ? Math.round(Number(minPrice) * 100) : null,
+      maxPriceCents: maxPrice ? Math.round(Number(maxPrice) * 100) : null,
+      maxDistanceKm: maxKm ? Number(maxKm) : null,
+      createdAt: new Date().toISOString(),
+    };
     try {
-      await postSearchHistory(token, {
-        query,
-        minPriceCents: minPrice
-          ? Math.round(Number(minPrice) * 100)
-          : undefined,
-        maxPriceCents: maxPrice
-          ? Math.round(Number(maxPrice) * 100)
-          : undefined,
-        maxDistanceKm: maxKm ? Number(maxKm) : undefined,
+      const created = await postSearchHistory(token, {
+        query: nextRow.query ?? undefined,
+        minPriceCents: nextRow.minPriceCents ?? undefined,
+        maxPriceCents: nextRow.maxPriceCents ?? undefined,
+        maxDistanceKm: nextRow.maxDistanceKm ?? undefined,
       });
+      setHistory((current) => [created, ...current]);
       setMsg("Search saved to history.");
       await refreshAll();
     } catch (e: unknown) {

--- a/webapp/lib/api.ts
+++ b/webapp/lib/api.ts
@@ -1,6 +1,24 @@
 import { getApiBase } from "./config";
 
 export type ApiError = { error?: string; message?: string };
+export type SearchHistoryPayload = {
+  query?: string;
+  minPriceCents?: number;
+  maxPriceCents?: number;
+  maxDistanceKm?: number;
+  latitude?: number;
+  longitude?: number;
+};
+export type SearchHistoryRow = {
+  id?: string;
+  query?: string | null;
+  minPriceCents?: number | null;
+  maxPriceCents?: number | null;
+  maxDistanceKm?: number | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  createdAt?: string;
+};
 export const LISTING_SEARCH_SORTS = [
   "created_desc",
   "listed_desc",
@@ -82,21 +100,19 @@ export async function loginUser(email: string, password: string) {
 
 export async function postSearchHistory(
   token: string,
-  body: {
-    query?: string;
-    minPriceCents?: number;
-    maxPriceCents?: number;
-    maxDistanceKm?: number;
-    latitude?: number;
-    longitude?: number;
-  },
+  body: SearchHistoryPayload,
 ) {
   const res = await apiFetch("/api/booking/search-history", {
     method: "POST",
     token,
     body: JSON.stringify(body),
+    cache: "no-store",
+    headers: {
+      "Cache-Control": "no-store",
+      Pragma: "no-cache",
+    },
   });
-  const data = await parseJson(res);
+  const data = (await parseJson(res)) as SearchHistoryRow;
   if (!res.ok)
     throw new Error(
       (data as ApiError)?.error || `search-history ${res.status}`,
@@ -110,9 +126,14 @@ export async function listSearchHistory(token: string, limit = 25) {
     {
       method: "GET",
       token,
+      cache: "no-store",
+      headers: {
+        "Cache-Control": "no-store",
+        Pragma: "no-cache",
+      },
     },
   );
-  const data = (await parseJson(res)) as { items?: unknown[] };
+  const data = (await parseJson(res)) as { items?: SearchHistoryRow[] };
   if (!res.ok)
     throw new Error(
       (data as ApiError)?.error || `list search-history ${res.status}`,


### PR DESCRIPTION
resolves #49 

This PR fixes the search history save flow so saved searches reliably persist through the API and appear in the dashboard after refresh.

The previous flow mostly worked at the route level, but stale/cached responses could make the save/list experience feel inconsistent. This update tightens the end-to-end behavior across the gateway, booking service, and webapp while preserving the existing API shape and dashboard workflow.

What changed:

API flow fixes
Prevented caching on search history routes in api-gateway
Disabled caching headers on booking-service search history save/list responses
Disabled etag generation in booking-service for fresher search history reads

Webapp fixes
Updated search history API calls to use no-store
Reused typed search history payload/row shapes in the webapp client
Updated the dashboard to show the newly saved search immediately, then refresh from the API

Coverage
Added integration assertions for search history cache headers in booking-service tests