### PR TITLE
fix(e2e): make listings visual regression tests deterministic and CI-safe

### DIFF
--- a/webapp/e2e/listings.visual.spec.ts
+++ b/webapp/e2e/listings.visual.spec.ts
@@ -29,7 +29,6 @@ const populatedListings = [
   },
 ];
 
-// Test on both desktop and mobile viewports
 const VIEWPORTS = [
   { name: "desktop", width: 1280, height: 800 },
   { name: "mobile", width: 390, height: 844 },
@@ -43,6 +42,11 @@ for (const viewport of VIEWPORTS) {
     });
 
     test.beforeEach(async ({ page }) => {
+      // Disable CSS animations/transitions to prevent rendering drift
+      await page.addStyleTag({
+        content: `*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; }`,
+      });
+
       // Block ALL external requests for full network isolation
       await page.route("**/*", async (route) => {
         const url = route.request().url();
@@ -69,6 +73,7 @@ for (const viewport of VIEWPORTS) {
       await page.goto("/listings");
       await page.waitForLoadState("networkidle");
       await expect(page.getByTestId("listings-results")).toBeVisible();
+      // Semantic assertion — catch non-visual regressions
       await expect(page.getByText("2 Bed near campus")).toBeVisible();
 
       await expect(page.getByTestId("listings-results")).toHaveScreenshot(
@@ -89,6 +94,8 @@ for (const viewport of VIEWPORTS) {
       await page.goto("/listings");
       await page.waitForLoadState("networkidle");
       await expect(page.getByTestId("listings-results")).toBeVisible();
+      // Semantic assertion
+      await expect(page.getByText("No listings matched your current filters.")).toBeVisible();
 
       await expect(page.getByTestId("listings-results")).toHaveScreenshot(
         `listings-results-empty-${viewport.name}.png`,
@@ -108,6 +115,8 @@ for (const viewport of VIEWPORTS) {
       await page.goto("/listings");
       await page.waitForLoadState("networkidle");
       await expect(page.getByTestId("listings-results")).toBeVisible();
+      // Semantic assertion
+      await expect(page.getByText("Could not load listings")).toBeVisible();
 
       await expect(page.getByTestId("listings-results")).toHaveScreenshot(
         `listings-results-error-${viewport.name}.png`,

--- a/webapp/e2e/listings.visual.spec.ts
+++ b/webapp/e2e/listings.visual.spec.ts
@@ -30,12 +30,17 @@ const populatedListings = [
 ];
 
 test.describe("listings page visual states", () => {
-  test.beforeEach(() => {
-    test.skip(
-      process.env.E2E_API_BASE === undefined,
-      "Requires running webapp/edge environment",
-    );
+  test.use({
+    // Always use local Next.js dev server for visual tests — no edge stack required
+    baseURL: process.env.VISUAL_TEST_BASE_URL || "http://localhost:3000",
   });
+
+  test.beforeEach(async ({ page }) => {
+    // Block Google Maps embed to avoid external dependency and layout drift
+    await page.route("**/maps.googleapis.com/**", (route) => route.abort());
+    await page.route("**/maps.gstatic.com/**", (route) => route.abort());
+  });
+
   test("populated results", async ({ page }) => {
     await page.route("**/api/listings/search*", async (route) => {
       await route.fulfill({
@@ -44,17 +49,12 @@ test.describe("listings page visual states", () => {
         body: JSON.stringify(populatedListings),
       });
     });
-
     await page.goto("/listings");
-
-    // wait for correct state
     await expect(page.getByTestId("listings-results")).toBeVisible();
-    await expect(page.getByText("Available listings")).toBeVisible();
-    await expect(page.getByText("2 listings found")).toBeVisible();
-
-    // snapshot
+    await expect(page.getByText("2 Bed near campus")).toBeVisible();
     await expect(page.getByTestId("listings-results")).toHaveScreenshot(
       "listings-results-populated.png",
+      { maxDiffPixelRatio: 0.02 },
     );
   });
 
@@ -66,18 +66,11 @@ test.describe("listings page visual states", () => {
         body: JSON.stringify([]),
       });
     });
-
     await page.goto("/listings");
-
-    // wait for correct state
     await expect(page.getByTestId("listings-results")).toBeVisible();
-    await expect(
-      page.getByText("No listings matched your current filters."),
-    ).toBeVisible();
-
-    // snapshot
     await expect(page.getByTestId("listings-results")).toHaveScreenshot(
       "listings-results-empty.png",
+      { maxDiffPixelRatio: 0.02 },
     );
   });
 
@@ -89,16 +82,11 @@ test.describe("listings page visual states", () => {
         body: JSON.stringify({ error: "listings search 500" }),
       });
     });
-
     await page.goto("/listings");
-
-    // wait for correct state
     await expect(page.getByTestId("listings-results")).toBeVisible();
-    await expect(page.getByText("Could not load listings")).toBeVisible();
-
-    // snapshot
     await expect(page.getByTestId("listings-results")).toHaveScreenshot(
       "listings-results-error.png",
+      { maxDiffPixelRatio: 0.02 },
     );
   });
 });

--- a/webapp/e2e/listings.visual.spec.ts
+++ b/webapp/e2e/listings.visual.spec.ts
@@ -29,64 +29,90 @@ const populatedListings = [
   },
 ];
 
-test.describe("listings page visual states", () => {
-  test.use({
-    // Always use local Next.js dev server for visual tests — no edge stack required
-    baseURL: process.env.VISUAL_TEST_BASE_URL || "http://localhost:3000",
-  });
+// Test on both desktop and mobile viewports
+const VIEWPORTS = [
+  { name: "desktop", width: 1280, height: 800 },
+  { name: "mobile", width: 390, height: 844 },
+];
 
-  test.beforeEach(async ({ page }) => {
-    // Block Google Maps embed to avoid external dependency and layout drift
-    await page.route("**/maps.googleapis.com/**", (route) => route.abort());
-    await page.route("**/maps.gstatic.com/**", (route) => route.abort());
-  });
+for (const viewport of VIEWPORTS) {
+  test.describe(`listings page visual states [${viewport.name}]`, () => {
+    test.use({
+      baseURL: process.env.VISUAL_TEST_BASE_URL || "http://localhost:3000",
+      viewport: { width: viewport.width, height: viewport.height },
+    });
 
-  test("populated results", async ({ page }) => {
-    await page.route("**/api/listings/search*", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(populatedListings),
+    test.beforeEach(async ({ page }) => {
+      // Block ALL external requests for full network isolation
+      await page.route("**/*", async (route) => {
+        const url = route.request().url();
+        if (
+          url.startsWith("http://localhost") ||
+          url.startsWith("http://127.0.0.1")
+        ) {
+          await route.continue();
+        } else {
+          await route.abort();
+        }
       });
     });
-    await page.goto("/listings");
-    await expect(page.getByTestId("listings-results")).toBeVisible();
-    await expect(page.getByText("2 Bed near campus")).toBeVisible();
-    await expect(page.getByTestId("listings-results")).toHaveScreenshot(
-      "listings-results-populated.png",
-      { maxDiffPixelRatio: 0.02 },
-    );
-  });
 
-  test("empty results", async ({ page }) => {
-    await page.route("**/api/listings/search*", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify([]),
+    test(`populated results [${viewport.name}]`, async ({ page }) => {
+      await page.route("**/api/listings/search*", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(populatedListings),
+        });
       });
-    });
-    await page.goto("/listings");
-    await expect(page.getByTestId("listings-results")).toBeVisible();
-    await expect(page.getByTestId("listings-results")).toHaveScreenshot(
-      "listings-results-empty.png",
-      { maxDiffPixelRatio: 0.02 },
-    );
-  });
 
-  test("error state", async ({ page }) => {
-    await page.route("**/api/listings/search*", async (route) => {
-      await route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({ error: "listings search 500" }),
-      });
+      await page.goto("/listings");
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("listings-results")).toBeVisible();
+      await expect(page.getByText("2 Bed near campus")).toBeVisible();
+
+      await expect(page.getByTestId("listings-results")).toHaveScreenshot(
+        `listings-results-populated-${viewport.name}.png`,
+        { maxDiffPixelRatio: 0.005 },
+      );
     });
-    await page.goto("/listings");
-    await expect(page.getByTestId("listings-results")).toBeVisible();
-    await expect(page.getByTestId("listings-results")).toHaveScreenshot(
-      "listings-results-error.png",
-      { maxDiffPixelRatio: 0.02 },
-    );
+
+    test(`empty results [${viewport.name}]`, async ({ page }) => {
+      await page.route("**/api/listings/search*", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([]),
+        });
+      });
+
+      await page.goto("/listings");
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("listings-results")).toBeVisible();
+
+      await expect(page.getByTestId("listings-results")).toHaveScreenshot(
+        `listings-results-empty-${viewport.name}.png`,
+        { maxDiffPixelRatio: 0.005 },
+      );
+    });
+
+    test(`error state [${viewport.name}]`, async ({ page }) => {
+      await page.route("**/api/listings/search*", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "listings search 500" }),
+        });
+      });
+
+      await page.goto("/listings");
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("listings-results")).toBeVisible();
+
+      await expect(page.getByTestId("listings-results")).toHaveScreenshot(
+        `listings-results-error-${viewport.name}.png`,
+        { maxDiffPixelRatio: 0.005 },
+      );
+    });
   });
-});
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,8 @@
     "test:e2e:smoke": "NODE_EXTRA_CA_CERTS=$PWD/../certs/dev-root.pem playwright test --project=01-guest-shell --project=04-analytics",
     "test:e2e:strict-edge": "sh ../scripts/webapp-playwright-strict-edge.sh",
     "test:e2e:ui": "NODE_EXTRA_CA_CERTS=$PWD/../certs/dev-root.pem playwright test --ui",
-    "test:e2e:headed": "NODE_EXTRA_CA_CERTS=$PWD/../certs/dev-root.pem playwright test --headed"
+    "test:e2e:headed": "NODE_EXTRA_CA_CERTS=$PWD/../certs/dev-root.pem playwright test --headed",
+    "test:e2e:visual": "PLAYWRIGHT_VISUAL_ONLY=1 VISUAL_TEST_BASE_URL=http://localhost:3000 playwright test --project=03-listings --grep listings.visual"
   },
   "dependencies": {
     "react": "^18",

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -73,6 +73,14 @@ const suiteProjects = [
 ] as const;
 
 export default defineConfig({
+  webServer: process.env.PLAYWRIGHT_VISUAL_ONLY
+    ? {
+        command: "pnpm --filter webapp dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: true,
+        timeout: 120_000,
+      }
+    : undefined,
   globalSetup: "./playwright.global-setup.ts",
   testDir: "./e2e",
   timeout: 120_000,


### PR DESCRIPTION
## What this PR does
Makes the listings page visual regression tests fully self-contained and CI-safe.

## Changes made

### 1. Remove environment skip guard (`listings.visual.spec.ts`)
- Removed `test.skip` that blocked tests when `E2E_API_BASE` was undefined
- Added `test.use({ baseURL })` to always use local Next.js server for visual tests
- Added `beforeEach` to block Google Maps external requests (prevents layout drift)
- Added `maxDiffPixelRatio: 0.02` tolerance for minor rendering differences

### 2. Add webServer config (`playwright.config.ts`)
- When `PLAYWRIGHT_VISUAL_ONLY=1`, Playwright starts `pnpm dev` automatically
- Uses `reuseExistingServer: true` so local dev server is reused if already running
- No edge stack or Docker required for visual tests

### 3. Add dedicated visual test script (`package.json`)
- `pnpm test:e2e:visual` runs only the visual tests against local Next.js
- Fully self-contained — no `E2E_API_BASE`, no Caddy, no Kubernetes needed

## Fixes
- Closes #102

## Run locally
cd webapp && pnpm test:e2e:visual