### PR TITLE
fix(a11y): audit and improve listings page accessibility

### DIFF
--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useReducer, useState } from "react";
+import { Suspense, useCallback, useEffect, useReducer, useState } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import {
   createListing,
   getListing,
@@ -57,6 +58,47 @@ function filtersReducer(state: ListingFilters, action: FilterAction): ListingFil
     case 'RESET': return DEFAULT_FILTERS;
     default: return state;
   }
+}
+
+// ---------------------------------------------------------------------------
+// URL ↔ filter state helpers
+// ---------------------------------------------------------------------------
+function filtersToParams(f: ListingFilters): URLSearchParams {
+  const p = new URLSearchParams();
+  if (f.q) p.set('q', f.q);
+  if (f.minPrice) p.set('min_price', f.minPrice);
+  if (f.maxPrice) p.set('max_price', f.maxPrice);
+  if (f.smokeFree) p.set('smoke_free', '1');
+  if (f.petFriendly) p.set('pet_friendly', '1');
+  if (f.furnishedOnly) p.set('furnished', '1');
+  const amenities: string[] = [];
+  if (f.filterGarage) amenities.push('garage');
+  if (f.filterParking) amenities.push('parking');
+  if (f.filterLaundry) amenities.push('in_unit_laundry');
+  if (f.filterDishwasher) amenities.push('dishwasher');
+  if (amenities.length) p.set('amenities', amenities.join(','));
+  if (f.newWithin) p.set('new_within', f.newWithin);
+  if (f.sortBy && f.sortBy !== 'created_desc') p.set('sort', f.sortBy);
+  return p;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function paramsToFilters(p: URLSearchParams): Partial<ListingFilters> {
+  const amenities = (p.get('amenities') || '').split(',');
+  return {
+    q: p.get('q') || '',
+    minPrice: p.get('min_price') || '',
+    maxPrice: p.get('max_price') || '',
+    smokeFree: p.get('smoke_free') === '1',
+    petFriendly: p.get('pet_friendly') === '1',
+    furnishedOnly: p.get('furnished') === '1',
+    filterGarage: amenities.includes('garage'),
+    filterParking: amenities.includes('parking'),
+    filterLaundry: amenities.includes('in_unit_laundry'),
+    filterDishwasher: amenities.includes('dishwasher'),
+    newWithin: p.get('new_within') || '',
+    sortBy: (p.get('sort') as ListingFilters['sortBy']) || 'created_desc',
+  };
 }
 
 const AMENITY_OPTIONS = [
@@ -785,7 +827,9 @@ function CreateListingSection({
   );
 }
 
-export default function ListingsPage() {
+function ListingsPageInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams(); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [email, setEmail] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
@@ -838,6 +882,13 @@ export default function ListingsPage() {
     setToken(getStoredToken());
     setEmail(getStoredEmail());
   }, []);
+
+  // Sync filter state → URL query params on every filter change
+  useEffect(() => {
+    const params = filtersToParams(filters);
+    const qs = params.toString();
+    router.replace(qs ? `/listings?${qs}` : '/listings', { scroll: false });
+  }, [filters]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const buildCreateAmenities = (): string[] => {
     const parts: string[] = [];
@@ -1082,5 +1133,13 @@ export default function ListingsPage() {
         />
       </main>
     </div>
+  );
+}
+
+export default function ListingsPage() {
+  return (
+    <Suspense>
+      <ListingsPageInner />
+    </Suspense>
   );
 }

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -396,7 +396,7 @@ function ListingsSearchSection({
               data-testid="listings-search-q"
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-900"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-900 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
               placeholder="studio, laundry…"
             />
           </div>
@@ -410,7 +410,7 @@ function ListingsSearchSection({
               step="0.01"
               value={minPrice}
               onChange={(e) => setMinPrice(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             />
           </div>
           <div>
@@ -423,7 +423,7 @@ function ListingsSearchSection({
               step="0.01"
               value={maxPrice}
               onChange={(e) => setMaxPrice(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             />
           </div>
         </div>
@@ -512,7 +512,7 @@ function ListingsSearchSection({
               data-testid="listings-sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as ListingSearchSort)}
-              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm"
+              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             >
               <option value="created_desc">Newest (created)</option>
               <option value="listed_desc">Listing date</option>
@@ -529,7 +529,7 @@ function ListingsSearchSection({
               data-testid="listings-new-within"
               value={newWithin}
               onChange={(e) => setNewWithin(e.target.value)}
-              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm"
+              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             >
               <option value="">Any time</option>
               <option value="7">Last 7 days</option>
@@ -541,7 +541,7 @@ function ListingsSearchSection({
             type="submit"
             disabled={searchLoading}
             data-testid="listings-search-submit"
-            className="rounded-full bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-600 disabled:opacity-50"
+            className="rounded-full bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 disabled:opacity-50"
           >
             Search
           </button>
@@ -591,7 +591,7 @@ function ListingLookupSection({
           type="submit"
           disabled={detailLoading}
           data-testid="listings-detail-load"
-          className="rounded-full border border-slate-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50 disabled:opacity-50"
+          className="rounded-full border border-slate-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:opacity-50"
         >
           Load
         </button>
@@ -692,7 +692,7 @@ function CreateListingSection({
             data-testid="listings-create-title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             required
           />
         </div>
@@ -705,7 +705,7 @@ function CreateListingSection({
             value={desc}
             onChange={(e) => setDesc(e.target.value)}
             rows={3}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
           />
         </div>
         <div>
@@ -718,7 +718,7 @@ function CreateListingSection({
             step="0.01"
             value={priceUsd}
             onChange={(e) => setPriceUsd(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             required
           />
         </div>
@@ -731,7 +731,7 @@ function CreateListingSection({
             type="date"
             value={effectiveFrom}
             onChange={(e) => setEffectiveFrom(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
             required
           />
         </div>
@@ -822,7 +822,7 @@ function CreateListingSection({
             type="submit"
             disabled={createLoading}
             data-testid="listings-create-submit"
-            className="rounded-full bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-600 disabled:opacity-50"
+            className="rounded-full bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 disabled:opacity-50"
           >
             Create listing
           </button>

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -504,10 +504,11 @@ function ListingsSearchSection({
         </p>
         <div className="mt-3 flex flex-wrap items-end gap-4">
           <div>
-            <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label htmlFor="listings-sort" className="text-xs font-medium uppercase tracking-wide text-slate-500">
               Sort by
             </label>
             <select
+              id="listings-sort"
               data-testid="listings-sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as ListingSearchSort)}
@@ -520,10 +521,11 @@ function ListingsSearchSection({
             </select>
           </div>
           <div>
-            <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label htmlFor="listings-new-within" className="text-xs font-medium uppercase tracking-wide text-slate-500">
               Listed recently
             </label>
             <select
+              id="listings-new-within"
               data-testid="listings-new-within"
               value={newWithin}
               onChange={(e) => setNewWithin(e.target.value)}

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import Link from "next/link";
 import {
   createListing,
@@ -17,7 +17,7 @@ import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
 // ---------------------------------------------------------------------------
 // Filter state — single source of truth for all search/filter fields
 // ---------------------------------------------------------------------------
-export type ListingFilters = {
+type ListingFilters = {
   q: string;
   minPrice: string;
   maxPrice: string;
@@ -32,7 +32,7 @@ export type ListingFilters = {
   newWithin: string;
 };
 
-export const DEFAULT_FILTERS: ListingFilters = {
+const DEFAULT_FILTERS: ListingFilters = {
   q: '',
   minPrice: '',
   maxPrice: '',
@@ -296,29 +296,29 @@ function ListingsSearchSection({
   onSearch,
 }: {
   q: string;
-  setQ: React.Dispatch<React.SetStateAction<string>>;
+  setQ: (v: string) => void;
   minPrice: string;
-  setMinPrice: React.Dispatch<React.SetStateAction<string>>;
+  setMinPrice: (v: string) => void;
   maxPrice: string;
-  setMaxPrice: React.Dispatch<React.SetStateAction<string>>;
+  setMaxPrice: (v: string) => void;
   smokeFree: boolean;
-  setSmokeFree: React.Dispatch<React.SetStateAction<boolean>>;
+  setSmokeFree: (v: boolean) => void;
   petFriendly: boolean;
-  setPetFriendly: React.Dispatch<React.SetStateAction<boolean>>;
+  setPetFriendly: (v: boolean) => void;
   furnishedOnly: boolean;
-  setFurnishedOnly: React.Dispatch<React.SetStateAction<boolean>>;
+  setFurnishedOnly: (v: boolean) => void;
   filterGarage: boolean;
-  setFilterGarage: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilterGarage: (v: boolean) => void;
   filterParking: boolean;
-  setFilterParking: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilterParking: (v: boolean) => void;
   filterLaundry: boolean;
-  setFilterLaundry: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilterLaundry: (v: boolean) => void;
   filterDishwasher: boolean;
-  setFilterDishwasher: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilterDishwasher: (v: boolean) => void;
   sortBy: ListingSearchSort;
-  setSortBy: React.Dispatch<React.SetStateAction<ListingSearchSort>>;
+  setSortBy: (v: ListingSearchSort) => void;
   newWithin: string;
-  setNewWithin: React.Dispatch<React.SetStateAction<string>>;
+  setNewWithin: (v: string) => void;
   searchLoading: boolean;
   onSearch: (e?: React.FormEvent) => Promise<void>;
 }) {
@@ -512,7 +512,7 @@ function ListingLookupSection({
   onLoadDetail,
 }: {
   detailId: string;
-  setDetailId: React.Dispatch<React.SetStateAction<string>>;
+  setDetailId: (v: string) => void;
   detailLoading: boolean;
   detail: ListingJson | null;
   onLoadDetail: (e: React.FormEvent) => Promise<void>;
@@ -592,31 +592,31 @@ function CreateListingSection({
   onCreate,
 }: {
   title: string;
-  setTitle: React.Dispatch<React.SetStateAction<string>>;
+  setTitle: (v: string) => void;
   desc: string;
-  setDesc: React.Dispatch<React.SetStateAction<string>>;
+  setDesc: (v: string) => void;
   priceUsd: string;
-  setPriceUsd: React.Dispatch<React.SetStateAction<string>>;
+  setPriceUsd: (v: string) => void;
   effectiveFrom: string;
-  setEffectiveFrom: React.Dispatch<React.SetStateAction<string>>;
+  setEffectiveFrom: (v: string) => void;
   createLat: string;
-  setCreateLat: React.Dispatch<React.SetStateAction<string>>;
+  setCreateLat: (v: string) => void;
   createLng: string;
-  setCreateLng: React.Dispatch<React.SetStateAction<string>>;
+  setCreateLng: (v: string) => void;
   createSmokeFree: boolean;
-  setCreateSmokeFree: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreateSmokeFree: (v: boolean) => void;
   createPetFriendly: boolean;
-  setCreatePetFriendly: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreatePetFriendly: (v: boolean) => void;
   createFurnished: boolean;
-  setCreateFurnished: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreateFurnished: (v: boolean) => void;
   createGarage: boolean;
-  setCreateGarage: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreateGarage: (v: boolean) => void;
   createParking: boolean;
-  setCreateParking: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreateParking: (v: boolean) => void;
   createLaundry: boolean;
-  setCreateLaundry: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreateLaundry: (v: boolean) => void;
   createDishwasher: boolean;
-  setCreateDishwasher: React.Dispatch<React.SetStateAction<boolean>>;
+  setCreateDishwasher: (v: boolean) => void;
   createLoading: boolean;
   onCreate: (e: React.FormEvent) => Promise<void>;
 }) {
@@ -789,18 +789,22 @@ export default function ListingsPage() {
   const [email, setEmail] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
-  const [q, setQ] = useState("");
-  const [minPrice, setMinPrice] = useState("");
-  const [maxPrice, setMaxPrice] = useState("");
-  const [smokeFree, setSmokeFree] = useState(false);
-  const [petFriendly, setPetFriendly] = useState(false);
-  const [furnishedOnly, setFurnishedOnly] = useState(false);
-  const [filterGarage, setFilterGarage] = useState(false);
-  const [filterParking, setFilterParking] = useState(false);
-  const [filterLaundry, setFilterLaundry] = useState(false);
-  const [filterDishwasher, setFilterDishwasher] = useState(false);
-  const [sortBy, setSortBy] = useState<ListingSearchSort>("created_desc");
-  const [newWithin, setNewWithin] = useState<string>("");
+  const [filters, dispatchFilters] = useReducer(filtersReducer, DEFAULT_FILTERS);
+  const { q, minPrice, maxPrice, smokeFree, petFriendly, furnishedOnly,
+    filterGarage, filterParking, filterLaundry, filterDishwasher,
+    sortBy, newWithin } = filters;
+  const setQ = (v: string) => dispatchFilters({ type: 'SET', payload: { q: v } });
+  const setMinPrice = (v: string) => dispatchFilters({ type: 'SET', payload: { minPrice: v } });
+  const setMaxPrice = (v: string) => dispatchFilters({ type: 'SET', payload: { maxPrice: v } });
+  const setSmokeFree = (v: boolean) => dispatchFilters({ type: 'SET', payload: { smokeFree: v } });
+  const setPetFriendly = (v: boolean) => dispatchFilters({ type: 'SET', payload: { petFriendly: v } });
+  const setFurnishedOnly = (v: boolean) => dispatchFilters({ type: 'SET', payload: { furnishedOnly: v } });
+  const setFilterGarage = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterGarage: v } });
+  const setFilterParking = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterParking: v } });
+  const setFilterLaundry = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterLaundry: v } });
+  const setFilterDishwasher = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterDishwasher: v } });
+  const setSortBy = (v: ListingSearchSort) => dispatchFilters({ type: 'SET', payload: { sortBy: v } });
+  const setNewWithin = (v: string) => dispatchFilters({ type: 'SET', payload: { newWithin: v } });
 
   const [items, setItems] = useState<ListingJson[]>([]);
   const [detail, setDetail] = useState<ListingJson | null>(null);

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -429,10 +429,10 @@ function ListingsSearchSection({
         </div>
       </div>
 
-      <div className="mt-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+      <fieldset className="mt-8 border-0 p-0 m-0">
+        <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
           Preferences and amenities
-        </p>
+        </legend>
         <div className="mt-3 flex flex-wrap gap-3 text-sm">
           <label className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-2">
             <input

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -157,7 +157,7 @@ function ListingsResultsSection({
             Available listings
           </h2>
         </div>
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-slate-500" role="status" aria-live="polite" aria-atomic="true">
           {searchLoading
             ? "Updating results…"
             : searchError
@@ -396,7 +396,7 @@ function ListingsSearchSection({
               data-testid="listings-search-q"
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-900 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-900 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
               placeholder="studio, laundry…"
             />
           </div>
@@ -410,7 +410,7 @@ function ListingsSearchSection({
               step="0.01"
               value={minPrice}
               onChange={(e) => setMinPrice(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             />
           </div>
           <div>
@@ -423,7 +423,7 @@ function ListingsSearchSection({
               step="0.01"
               value={maxPrice}
               onChange={(e) => setMaxPrice(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             />
           </div>
         </div>
@@ -512,7 +512,7 @@ function ListingsSearchSection({
               data-testid="listings-sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as ListingSearchSort)}
-              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             >
               <option value="created_desc">Newest (created)</option>
               <option value="listed_desc">Listing date</option>
@@ -529,7 +529,7 @@ function ListingsSearchSection({
               data-testid="listings-new-within"
               value={newWithin}
               onChange={(e) => setNewWithin(e.target.value)}
-              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             >
               <option value="">Any time</option>
               <option value="7">Last 7 days</option>
@@ -692,7 +692,7 @@ function CreateListingSection({
             data-testid="listings-create-title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             required
           />
         </div>
@@ -705,7 +705,7 @@ function CreateListingSection({
             value={desc}
             onChange={(e) => setDesc(e.target.value)}
             rows={3}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
           />
         </div>
         <div>
@@ -718,7 +718,7 @@ function CreateListingSection({
             step="0.01"
             value={priceUsd}
             onChange={(e) => setPriceUsd(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             required
           />
         </div>
@@ -731,7 +731,7 @@ function CreateListingSection({
             type="date"
             value={effectiveFrom}
             onChange={(e) => setEffectiveFrom(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus-visible:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             required
           />
         </div>
@@ -1042,6 +1042,7 @@ function ListingsPageInner() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-teal-50/30 text-slate-900">
+      <a href="#listings-results" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:bg-teal-700 focus:px-4 focus:py-2 focus:text-white focus:text-sm focus:font-semibold">Skip to listings</a>
       <Nav email={email} />
       <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-12">
         <ListingsHeaderSection />

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -61,7 +61,7 @@ function filtersReducer(state: ListingFilters, action: FilterAction): ListingFil
 }
 
 // ---------------------------------------------------------------------------
-// URL ↔ filter state helpers
+// URL <-> filter state helpers
 // ---------------------------------------------------------------------------
 function filtersToParams(f: ListingFilters): URLSearchParams {
   const p = new URLSearchParams();
@@ -396,7 +396,7 @@ function ListingsSearchSection({
               data-testid="listings-search-q"
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-900 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-900 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
               placeholder="studio, laundry…"
             />
           </div>
@@ -410,7 +410,7 @@ function ListingsSearchSection({
               step="0.01"
               value={minPrice}
               onChange={(e) => setMinPrice(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             />
           </div>
           <div>
@@ -423,7 +423,7 @@ function ListingsSearchSection({
               step="0.01"
               value={maxPrice}
               onChange={(e) => setMaxPrice(e.target.value)}
-              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             />
           </div>
         </div>
@@ -496,7 +496,7 @@ function ListingsSearchSection({
             Dishwasher
           </label>
         </div>
-      </div>
+      </fieldset>
 
       <div className="mt-8">
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
@@ -512,7 +512,7 @@ function ListingsSearchSection({
               data-testid="listings-sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as ListingSearchSort)}
-              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             >
               <option value="created_desc">Newest (created)</option>
               <option value="listed_desc">Listing date</option>
@@ -529,7 +529,7 @@ function ListingsSearchSection({
               data-testid="listings-new-within"
               value={newWithin}
               onChange={(e) => setNewWithin(e.target.value)}
-              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+              className="mt-1 block rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             >
               <option value="">Any time</option>
               <option value="7">Last 7 days</option>
@@ -692,7 +692,7 @@ function CreateListingSection({
             data-testid="listings-create-title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             required
           />
         </div>
@@ -705,7 +705,7 @@ function CreateListingSection({
             value={desc}
             onChange={(e) => setDesc(e.target.value)}
             rows={3}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
           />
         </div>
         <div>
@@ -718,7 +718,7 @@ function CreateListingSection({
             step="0.01"
             value={priceUsd}
             onChange={(e) => setPriceUsd(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             required
           />
         </div>
@@ -731,7 +731,7 @@ function CreateListingSection({
             type="date"
             value={effectiveFrom}
             onChange={(e) => setEffectiveFrom(e.target.value)}
-            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30"
+            className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
             required
           />
         </div>

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -13,6 +13,52 @@ import { getStoredEmail, getStoredToken } from "@/lib/auth-storage";
 import { Nav } from "@/components/Nav";
 import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
 
+
+// ---------------------------------------------------------------------------
+// Filter state — single source of truth for all search/filter fields
+// ---------------------------------------------------------------------------
+export type ListingFilters = {
+  q: string;
+  minPrice: string;
+  maxPrice: string;
+  smokeFree: boolean;
+  petFriendly: boolean;
+  furnishedOnly: boolean;
+  filterGarage: boolean;
+  filterParking: boolean;
+  filterLaundry: boolean;
+  filterDishwasher: boolean;
+  sortBy: ListingSearchSort;
+  newWithin: string;
+};
+
+export const DEFAULT_FILTERS: ListingFilters = {
+  q: '',
+  minPrice: '',
+  maxPrice: '',
+  smokeFree: false,
+  petFriendly: false,
+  furnishedOnly: false,
+  filterGarage: false,
+  filterParking: false,
+  filterLaundry: false,
+  filterDishwasher: false,
+  sortBy: 'created_desc',
+  newWithin: '',
+};
+
+type FilterAction =
+  | { type: 'SET'; payload: Partial<ListingFilters> }
+  | { type: 'RESET' };
+
+function filtersReducer(state: ListingFilters, action: FilterAction): ListingFilters {
+  switch (action.type) {
+    case 'SET': return { ...state, ...action.payload };
+    case 'RESET': return DEFAULT_FILTERS;
+    default: return state;
+  }
+}
+
 const AMENITY_OPTIONS = [
   { slug: "garage", label: "Garage" },
   { slug: "parking", label: "Parking" },

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -388,10 +388,11 @@ function ListingsSearchSection({
         </p>
         <div className="mt-3 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           <div className="md:col-span-2">
-            <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label htmlFor="listings-q" className="text-xs font-medium uppercase tracking-wide text-slate-500">
               Keywords
             </label>
             <input
+              id="listings-q"
               data-testid="listings-search-q"
               value={q}
               onChange={(e) => setQ(e.target.value)}
@@ -400,10 +401,11 @@ function ListingsSearchSection({
             />
           </div>
           <div>
-            <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label htmlFor="listings-min-price" className="text-xs font-medium uppercase tracking-wide text-slate-500">
               Min price (USD)
             </label>
             <input
+              id="listings-min-price"
               type="number"
               step="0.01"
               value={minPrice}
@@ -412,10 +414,11 @@ function ListingsSearchSection({
             />
           </div>
           <div>
-            <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label htmlFor="listings-max-price" className="text-xs font-medium uppercase tracking-wide text-slate-500">
               Max price (USD)
             </label>
             <input
+              id="listings-max-price"
               type="number"
               step="0.01"
               value={maxPrice}


### PR DESCRIPTION
## What this PR does
Incremental accessibility improvements to the listings page covering keyboard navigation, focus visibility, and semantic structure.

## Changes made (incremental commits)

### 1. `htmlFor`/`id` on search inputs
- Keywords, min price, max price inputs now have matching `id` and `htmlFor` attributes

### 2. `fieldset`/`legend` for checkbox group
- Wrapped "Preferences and amenities" checkbox group in `<fieldset>` with `<legend>`

### 3. `htmlFor`/`id` on sort and recency selects
- Sort by and Listed recently selects now have matching `id` and `htmlFor`

### 4. Focus ring styles on all interactive elements
- Added `focus:outline-none focus:ring-2 focus:ring-teal-500` to all inputs and selects
- Added `focus-visible:ring-2` to all buttons

## Fixes
- Closes #105

## Builds on
- #103 (centralized filter state)
- #104 (URL sync)

## Testing
- Tab through the listings page to verify focus order
- Use keyboard only to submit a search
- Check browser DevTools accessibility tree