### PR TITLE
feat(webapp): redesign trust page UI and improve moderation UX

### DIFF
--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -102,17 +102,34 @@ export default function TrustPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-50 via-white to-emerald-50/50 text-slate-900">
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-teal-50/30 text-slate-900">
       <Nav email={email} />
-      <main className="mx-auto max-w-3xl px-4 py-10">
-        <h1 className="font-serif text-3xl text-slate-900">Trust &amp; safety</h1>
-        <p className="mt-2 text-sm text-slate-600">
-          Report abuse and submit peer reviews via gateway → trust-service. Reputation lookup is public.
-        </p>
+      <main className="mx-auto max-w-5xl px-4 py-10 sm:px-6 sm:py-12">
+        <section className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+            Trust & safety
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+            Manage trust, safety, and reputation
+          </h1>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            Report abuse, submit peer reviews, and look up user reputation.
+            These tools help maintain a safe and trustworthy housing community.
+          </p>
+        </section>
 
-        <section className="mt-10 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
-          <h2 className="text-lg font-medium text-slate-900">Reputation</h2>
-          <form data-testid="trust-reputation-form" onSubmit={onReputation} className="mt-4 flex flex-col gap-3 sm:flex-row">
+        <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+            Moderation
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+            Report abuse
+          </h2>
+          <form
+            data-testid="trust-reputation-form"
+            onSubmit={onReputation}
+            className="mt-4 flex flex-col gap-3 sm:flex-row"
+          >
             <input
               data-testid="trust-reputation-user-id"
               value={repUserId}
@@ -139,7 +156,10 @@ export default function TrustPage() {
             </button>
           )}
           {repScore != null && (
-            <p data-testid="trust-reputation-score" className="mt-4 text-sm text-slate-600">
+            <p
+              data-testid="trust-reputation-score"
+              className="mt-4 text-sm text-slate-600"
+            >
               Score: <strong className="text-teal-800">{repScore}</strong>
             </p>
           )}
@@ -147,9 +167,17 @@ export default function TrustPage() {
 
         {token ? (
           <>
-            <section className="mt-8 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
-              <h2 className="text-lg font-medium text-slate-900">Report abuse</h2>
-              <form onSubmit={onReport} className="mt-4 space-y-3">
+            <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+              <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+                Reputation
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                Look up a user’s reputation
+              </h2>
+              <form
+                onSubmit={onReport}
+                className="mt-4 space-y-3"
+              >
                 <div className="flex gap-4 text-sm text-slate-700">
                   <label className="flex items-center gap-2">
                     <input
@@ -200,12 +228,21 @@ export default function TrustPage() {
               </form>
             </section>
 
-            <section className="mt-8 rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
-              <h2 className="text-lg font-medium text-slate-900">Peer review</h2>
-              <p className="mt-1 text-xs text-slate-600">
-                After a booking — both sides can leave a review (unique per booking/reviewer).
+            <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+              <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+                Reviews
               </p>
-              <form onSubmit={onPeerReview} className="mt-4 space-y-3">
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                Submit a peer review
+              </h2>
+              <p className="mt-1 text-xs text-slate-600">
+                After a booking — both sides can leave a review (unique per
+                booking/reviewer).
+              </p>
+              <form
+                onSubmit={onPeerReview}
+                className="mt-4 space-y-3"
+              >
                 <input
                   value={bookingId}
                   onChange={(e) => setBookingId(e.target.value)}
@@ -255,15 +292,20 @@ export default function TrustPage() {
             </section>
           </>
         ) : (
-          <p className="mt-8 text-sm text-slate-600">
-            <Link href="/login" className="font-medium text-teal-700 hover:underline">
+          <div className="mt-10 rounded-[1.25rem] border border-slate-200 bg-white px-5 py-4 text-sm text-slate-600 shadow-sm">
+            <Link
+              href="/login"
+              className="font-medium text-teal-700 hover:underline"
+            >
               Log in
             </Link>{" "}
             to report abuse or submit peer reviews.
-          </p>
+          </div>
         )}
 
-        {msg && <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>}
+        {msg && (
+          <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>
+        )}
         {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
       </main>
     </div>

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -50,6 +50,7 @@ function ReputationSection({
       <form
         data-testid="trust-reputation-form"
         onSubmit={onReputation}
+        aria-busy={loading}
         className="mt-4 flex flex-col gap-3 sm:flex-row"
       >
         <input
@@ -65,7 +66,7 @@ function ReputationSection({
           data-testid="trust-reputation-submit"
           className="rounded-md bg-teal-600 px-4 py-2 font-medium text-white hover:bg-teal-500 disabled:opacity-50"
         >
-          Look up
+          {loading ? "Looking up…" : "Look up"}
         </button>
       </form>
       {mySub && (
@@ -122,6 +123,7 @@ function ReportAbuseSection({
       </h2>
       <form
         onSubmit={onReport}
+        aria-busy={loading}
         className="mt-4 space-y-3"
       >
         <div className="flex gap-4 text-sm text-slate-700">
@@ -169,7 +171,7 @@ function ReportAbuseSection({
           disabled={loading}
           className="rounded-md border border-red-200 bg-red-50 px-4 py-2 font-medium text-red-800 hover:bg-red-100 disabled:opacity-50"
         >
-          Submit report
+          {loading ? "Submitting report…" : "Submit report"}
         </button>
       </form>
     </section>
@@ -217,6 +219,7 @@ function PeerReviewSection({
       </p>
       <form
         onSubmit={onPeerReview}
+        aria-busy={loading}
         className="mt-4 space-y-3"
       >
         <input
@@ -262,7 +265,7 @@ function PeerReviewSection({
           disabled={loading}
           className="rounded-md bg-slate-700 px-4 py-2 font-medium text-white hover:bg-slate-600 disabled:opacity-50"
         >
-          Submit review
+          {loading ? "Submitting review…" : "Submit review"}
         </button>
       </form>
     </section>
@@ -293,9 +296,22 @@ function TrustFeedback({
   return (
     <>
       {msg && (
-        <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>
+        <div
+          role="status"
+          aria-live="polite"
+          className="mt-6 rounded-[1.25rem] border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800 shadow-sm"
+        >
+          {msg}
+        </div>
       )}
-      {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
+      {err && (
+        <div
+          role="alert"
+          className="mt-4 rounded-[1.25rem] border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-700 shadow-sm"
+        >
+          {err}
+        </div>
+      )}
     </>
   );
 }
@@ -335,6 +351,7 @@ export default function TrustPage() {
   async function onReputation(e: React.FormEvent) {
     e.preventDefault();
     if (!repUserId.trim()) return;
+    setMsg(null);
     setErr(null);
     setLoading(true);
     try {

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -7,6 +7,299 @@ import { getStoredEmail, getStoredToken } from "@/lib/auth-storage";
 import { getSubFromJwt } from "@/lib/jwt-sub";
 import { Nav } from "@/components/Nav";
 
+function TrustHeaderSection() {
+  return (
+    <section className="max-w-3xl">
+      <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+        Trust & safety
+      </p>
+      <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+        Manage trust, safety, and reputation
+      </h1>
+      <p className="mt-4 text-lg leading-8 text-slate-600">
+        Report abuse, submit peer reviews, and look up user reputation. These
+        tools help maintain a safe and trustworthy housing community.
+      </p>
+    </section>
+  );
+}
+
+function ReputationSection({
+  repUserId,
+  setRepUserId,
+  onReputation,
+  loading,
+  mySub,
+  repScore,
+}: {
+  repUserId: string;
+  setRepUserId: React.Dispatch<React.SetStateAction<string>>;
+  onReputation: (e: React.FormEvent) => Promise<void>;
+  loading: boolean;
+  mySub: string | null;
+  repScore: number | null;
+}) {
+  return (
+    <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+        Reputation
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+        Look up a user’s reputation
+      </h2>
+      <form
+        data-testid="trust-reputation-form"
+        onSubmit={onReputation}
+        className="mt-4 flex flex-col gap-3 sm:flex-row"
+      >
+        <input
+          data-testid="trust-reputation-user-id"
+          value={repUserId}
+          onChange={(e) => setRepUserId(e.target.value)}
+          placeholder="user UUID"
+          className="flex-1 rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          data-testid="trust-reputation-submit"
+          className="rounded-md bg-teal-600 px-4 py-2 font-medium text-white hover:bg-teal-500 disabled:opacity-50"
+        >
+          Look up
+        </button>
+      </form>
+      {mySub && (
+        <button
+          type="button"
+          className="mt-2 text-xs font-medium text-teal-700 hover:underline"
+          onClick={() => setRepUserId(mySub)}
+        >
+          Use my account id
+        </button>
+      )}
+      {repScore != null && (
+        <p
+          data-testid="trust-reputation-score"
+          className="mt-4 text-sm text-slate-600"
+        >
+          Score: <strong className="text-teal-800">{repScore}</strong>
+        </p>
+      )}
+    </section>
+  );
+}
+
+function ReportAbuseSection({
+  abuseType,
+  setAbuseType,
+  abuseTarget,
+  setAbuseTarget,
+  abuseCategory,
+  setAbuseCategory,
+  abuseDetails,
+  setAbuseDetails,
+  onReport,
+  loading,
+}: {
+  abuseType: "listing" | "user";
+  setAbuseType: React.Dispatch<React.SetStateAction<"listing" | "user">>;
+  abuseTarget: string;
+  setAbuseTarget: React.Dispatch<React.SetStateAction<string>>;
+  abuseCategory: string;
+  setAbuseCategory: React.Dispatch<React.SetStateAction<string>>;
+  abuseDetails: string;
+  setAbuseDetails: React.Dispatch<React.SetStateAction<string>>;
+  onReport: (e: React.FormEvent) => Promise<void>;
+  loading: boolean;
+}) {
+  return (
+    <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+        Moderation
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+        Report abuse
+      </h2>
+      <form
+        onSubmit={onReport}
+        className="mt-4 space-y-3"
+      >
+        <div className="flex gap-4 text-sm text-slate-700">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="abuseType"
+              checked={abuseType === "listing"}
+              onChange={() => setAbuseType("listing")}
+            />
+            Listing
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="abuseType"
+              checked={abuseType === "user"}
+              onChange={() => setAbuseType("user")}
+            />
+            User
+          </label>
+        </div>
+        <input
+          value={abuseTarget}
+          onChange={(e) => setAbuseTarget(e.target.value)}
+          placeholder="target UUID"
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
+          required
+        />
+        <input
+          value={abuseCategory}
+          onChange={(e) => setAbuseCategory(e.target.value)}
+          placeholder="category"
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
+        />
+        <textarea
+          value={abuseDetails}
+          onChange={(e) => setAbuseDetails(e.target.value)}
+          placeholder="details (optional)"
+          rows={3}
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-md border border-red-200 bg-red-50 px-4 py-2 font-medium text-red-800 hover:bg-red-100 disabled:opacity-50"
+        >
+          Submit report
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function PeerReviewSection({
+  bookingId,
+  setBookingId,
+  revieweeId,
+  setRevieweeId,
+  side,
+  setSide,
+  rating,
+  setRating,
+  comment,
+  setComment,
+  onPeerReview,
+  loading,
+}: {
+  bookingId: string;
+  setBookingId: React.Dispatch<React.SetStateAction<string>>;
+  revieweeId: string;
+  setRevieweeId: React.Dispatch<React.SetStateAction<string>>;
+  side: string;
+  setSide: React.Dispatch<React.SetStateAction<string>>;
+  rating: number;
+  setRating: React.Dispatch<React.SetStateAction<number>>;
+  comment: string;
+  setComment: React.Dispatch<React.SetStateAction<string>>;
+  onPeerReview: (e: React.FormEvent) => Promise<void>;
+  loading: boolean;
+}) {
+  return (
+    <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+        Reviews
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+        Submit a peer review
+      </h2>
+      <p className="mt-1 text-xs text-slate-600">
+        After a booking — both sides can leave a review (unique per
+        booking/reviewer).
+      </p>
+      <form
+        onSubmit={onPeerReview}
+        className="mt-4 space-y-3"
+      >
+        <input
+          value={bookingId}
+          onChange={(e) => setBookingId(e.target.value)}
+          placeholder="booking UUID"
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
+          required
+        />
+        <input
+          value={revieweeId}
+          onChange={(e) => setRevieweeId(e.target.value)}
+          placeholder="reviewee user UUID"
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
+          required
+        />
+        <input
+          value={side}
+          onChange={(e) => setSide(e.target.value)}
+          placeholder="side label e.g. guest | host"
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
+        />
+        <div>
+          <label className="text-xs text-slate-600">Rating 1–5</label>
+          <input
+            type="number"
+            min={1}
+            max={5}
+            value={rating}
+            onChange={(e) => setRating(Number(e.target.value))}
+            className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm"
+          />
+        </div>
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="comment"
+          rows={2}
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-md bg-slate-700 px-4 py-2 font-medium text-white hover:bg-slate-600 disabled:opacity-50"
+        >
+          Submit review
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function TrustLoginPrompt() {
+  return (
+    <div className="mt-10 rounded-[1.25rem] border border-slate-200 bg-white px-5 py-4 text-sm text-slate-600 shadow-sm">
+      <Link
+        href="/login"
+        className="font-medium text-teal-700 hover:underline"
+      >
+        Log in
+      </Link>{" "}
+      to report abuse or submit peer reviews.
+    </div>
+  );
+}
+
+function TrustFeedback({
+  msg,
+  err,
+}: {
+  msg: string | null;
+  err: string | null;
+}) {
+  return (
+    <>
+      {msg && (
+        <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>
+      )}
+      {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
+    </>
+  );
+}
+
 export default function TrustPage() {
   const [email, setEmail] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
@@ -105,208 +398,54 @@ export default function TrustPage() {
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-teal-50/30 text-slate-900">
       <Nav email={email} />
       <main className="mx-auto max-w-5xl px-4 py-10 sm:px-6 sm:py-12">
-        <section className="max-w-3xl">
-          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
-            Trust & safety
-          </p>
-          <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-            Manage trust, safety, and reputation
-          </h1>
-          <p className="mt-4 text-lg leading-8 text-slate-600">
-            Report abuse, submit peer reviews, and look up user reputation.
-            These tools help maintain a safe and trustworthy housing community.
-          </p>
-        </section>
+        <TrustHeaderSection />
 
-        <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
-            Moderation
-          </p>
-          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
-            Report abuse
-          </h2>
-          <form
-            data-testid="trust-reputation-form"
-            onSubmit={onReputation}
-            className="mt-4 flex flex-col gap-3 sm:flex-row"
-          >
-            <input
-              data-testid="trust-reputation-user-id"
-              value={repUserId}
-              onChange={(e) => setRepUserId(e.target.value)}
-              placeholder="user UUID"
-              className="flex-1 rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
-            />
-            <button
-              type="submit"
-              disabled={loading}
-              data-testid="trust-reputation-submit"
-              className="rounded-md bg-teal-600 px-4 py-2 font-medium text-white hover:bg-teal-500 disabled:opacity-50"
-            >
-              Look up
-            </button>
-          </form>
-          {mySub && (
-            <button
-              type="button"
-              className="mt-2 text-xs font-medium text-teal-700 hover:underline"
-              onClick={() => setRepUserId(mySub)}
-            >
-              Use my account id
-            </button>
-          )}
-          {repScore != null && (
-            <p
-              data-testid="trust-reputation-score"
-              className="mt-4 text-sm text-slate-600"
-            >
-              Score: <strong className="text-teal-800">{repScore}</strong>
-            </p>
-          )}
-        </section>
+        <ReputationSection
+          repUserId={repUserId}
+          setRepUserId={setRepUserId}
+          onReputation={onReputation}
+          loading={loading}
+          mySub={mySub}
+          repScore={repScore}
+        />
 
         {token ? (
           <>
-            <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-              <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
-                Reputation
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
-                Look up a user’s reputation
-              </h2>
-              <form
-                onSubmit={onReport}
-                className="mt-4 space-y-3"
-              >
-                <div className="flex gap-4 text-sm text-slate-700">
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      name="abuseType"
-                      checked={abuseType === "listing"}
-                      onChange={() => setAbuseType("listing")}
-                    />
-                    Listing
-                  </label>
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      name="abuseType"
-                      checked={abuseType === "user"}
-                      onChange={() => setAbuseType("user")}
-                    />
-                    User
-                  </label>
-                </div>
-                <input
-                  value={abuseTarget}
-                  onChange={(e) => setAbuseTarget(e.target.value)}
-                  placeholder="target UUID"
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
-                  required
-                />
-                <input
-                  value={abuseCategory}
-                  onChange={(e) => setAbuseCategory(e.target.value)}
-                  placeholder="category"
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
-                />
-                <textarea
-                  value={abuseDetails}
-                  onChange={(e) => setAbuseDetails(e.target.value)}
-                  placeholder="details (optional)"
-                  rows={3}
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
-                />
-                <button
-                  type="submit"
-                  disabled={loading}
-                  className="rounded-md border border-red-200 bg-red-50 px-4 py-2 font-medium text-red-800 hover:bg-red-100 disabled:opacity-50"
-                >
-                  Submit report
-                </button>
-              </form>
-            </section>
-
-            <section className="mt-10 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-              <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
-                Reviews
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
-                Submit a peer review
-              </h2>
-              <p className="mt-1 text-xs text-slate-600">
-                After a booking — both sides can leave a review (unique per
-                booking/reviewer).
-              </p>
-              <form
-                onSubmit={onPeerReview}
-                className="mt-4 space-y-3"
-              >
-                <input
-                  value={bookingId}
-                  onChange={(e) => setBookingId(e.target.value)}
-                  placeholder="booking UUID"
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
-                  required
-                />
-                <input
-                  value={revieweeId}
-                  onChange={(e) => setRevieweeId(e.target.value)}
-                  placeholder="reviewee user UUID"
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
-                  required
-                />
-                <input
-                  value={side}
-                  onChange={(e) => setSide(e.target.value)}
-                  placeholder="side label e.g. guest | host"
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
-                />
-                <div>
-                  <label className="text-xs text-slate-600">Rating 1–5</label>
-                  <input
-                    type="number"
-                    min={1}
-                    max={5}
-                    value={rating}
-                    onChange={(e) => setRating(Number(e.target.value))}
-                    className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm"
-                  />
-                </div>
-                <textarea
-                  value={comment}
-                  onChange={(e) => setComment(e.target.value)}
-                  placeholder="comment"
-                  rows={2}
-                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
-                />
-                <button
-                  type="submit"
-                  disabled={loading}
-                  className="rounded-md bg-slate-700 px-4 py-2 font-medium text-white hover:bg-slate-600 disabled:opacity-50"
-                >
-                  Submit review
-                </button>
-              </form>
-            </section>
+            <ReportAbuseSection
+              abuseType={abuseType}
+              setAbuseType={setAbuseType}
+              abuseTarget={abuseTarget}
+              setAbuseTarget={setAbuseTarget}
+              abuseCategory={abuseCategory}
+              setAbuseCategory={setAbuseCategory}
+              abuseDetails={abuseDetails}
+              setAbuseDetails={setAbuseDetails}
+              onReport={onReport}
+              loading={loading}
+            />
+            <PeerReviewSection
+              bookingId={bookingId}
+              setBookingId={setBookingId}
+              revieweeId={revieweeId}
+              setRevieweeId={setRevieweeId}
+              side={side}
+              setSide={setSide}
+              rating={rating}
+              setRating={setRating}
+              comment={comment}
+              setComment={setComment}
+              onPeerReview={onPeerReview}
+              loading={loading}
+            />
           </>
         ) : (
-          <div className="mt-10 rounded-[1.25rem] border border-slate-200 bg-white px-5 py-4 text-sm text-slate-600 shadow-sm">
-            <Link
-              href="/login"
-              className="font-medium text-teal-700 hover:underline"
-            >
-              Log in
-            </Link>{" "}
-            to report abuse or submit peer reviews.
-          </div>
+          <TrustLoginPrompt />
         )}
 
-        {msg && (
-          <p className="mt-6 text-sm font-medium text-emerald-700">{msg}</p>
-        )}
-        {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
+        <TrustFeedback
+          msg={msg}
+          err={err}
+        />
       </main>
     </div>
   );

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -287,32 +287,31 @@ function TrustLoginPrompt() {
 }
 
 function TrustFeedback({
-  msg,
-  err,
+  feedback,
 }: {
-  msg: string | null;
-  err: string | null;
+  feedback: { type: "success" | "error" | null; message: string };
 }) {
+  if (!feedback.type) return null;
+
+  if (feedback.type === "success") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mt-6 rounded-[1.25rem] border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800 shadow-sm"
+      >
+        {feedback.message}
+      </div>
+    );
+  }
+
   return (
-    <>
-      {msg && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="mt-6 rounded-[1.25rem] border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800 shadow-sm"
-        >
-          {msg}
-        </div>
-      )}
-      {err && (
-        <div
-          role="alert"
-          className="mt-4 rounded-[1.25rem] border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-700 shadow-sm"
-        >
-          {err}
-        </div>
-      )}
-    </>
+    <div
+      role="alert"
+      className="mt-4 rounded-[1.25rem] border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-700 shadow-sm"
+    >
+      {feedback.message}
+    </div>
   );
 }
 
@@ -336,8 +335,15 @@ export default function TrustPage() {
   const [comment, setComment] = useState("");
 
   const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-  const [msg, setMsg] = useState<string | null>(null);
+  type FeedbackState = {
+    type: "success" | "error" | null;
+    message: string;
+  };
+
+  const [feedback, setFeedback] = useState<FeedbackState>({
+    type: null,
+    message: "",
+  });
 
   useEffect(() => {
     const t = getStoredToken();
@@ -351,16 +357,21 @@ export default function TrustPage() {
   async function onReputation(e: React.FormEvent) {
     e.preventDefault();
     if (loading) return;
-    setMsg(null);
-    setErr(null);
+    setFeedback({ type: null, message: "" });
     setLoading(true);
     try {
       const r = await getReputation(repUserId.trim());
       setRepScore(r.score);
-      setMsg(`Reputation for ${r.user_id}: ${r.score}`);
+      setFeedback({
+        type: "success",
+        message: `Reputation for ${r.user_id}: ${r.score}`,
+      });
     } catch (e: unknown) {
       setRepScore(null);
-      setErr(e instanceof Error ? e.message : "Lookup failed");
+      setFeedback({
+        type: "error",
+        message: e instanceof Error ? e.message : "Lookup failed",
+      });
     } finally {
       setLoading(false);
     }
@@ -370,8 +381,7 @@ export default function TrustPage() {
     e.preventDefault();
     if (loading) return;
     if (!token) return;
-    setMsg(null);
-    setErr(null);
+    setFeedback({ type: null, message: "" });
     setLoading(true);
     try {
       await reportAbuse(token, {
@@ -380,10 +390,16 @@ export default function TrustPage() {
         category: abuseCategory,
         details: abuseDetails,
       });
-      setMsg("Report submitted.");
+      setFeedback({
+        type: "success",
+        message: "Report submitted.",
+      });
       setAbuseDetails("");
     } catch (e: unknown) {
-      setErr(e instanceof Error ? e.message : "Report failed");
+      setFeedback({
+        type: "error",
+        message: e instanceof Error ? e.message : "Report failed",
+      });
     } finally {
       setLoading(false);
     }
@@ -393,8 +409,7 @@ export default function TrustPage() {
     e.preventDefault();
     if (loading) return;
     if (!token) return;
-    setMsg(null);
-    setErr(null);
+    setFeedback({ type: null, message: "" });
     setLoading(true);
     try {
       await submitPeerReview(token, {
@@ -404,10 +419,16 @@ export default function TrustPage() {
         rating,
         comment,
       });
-      setMsg("Peer review submitted.");
+      setFeedback({
+        type: "success",
+        message: "Peer review submitted.",
+      });
       setComment("");
     } catch (e: unknown) {
-      setErr(e instanceof Error ? e.message : "Review failed");
+      setFeedback({
+        type: "error",
+        message: e instanceof Error ? e.message : "Review failed",
+      });
     } finally {
       setLoading(false);
     }
@@ -461,10 +482,7 @@ export default function TrustPage() {
           <TrustLoginPrompt />
         )}
 
-        <TrustFeedback
-          msg={msg}
-          err={err}
-        />
+        <TrustFeedback feedback={feedback} />
       </main>
     </div>
   );

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -350,7 +350,7 @@ export default function TrustPage() {
 
   async function onReputation(e: React.FormEvent) {
     e.preventDefault();
-    if (!repUserId.trim()) return;
+    if (loading) return;
     setMsg(null);
     setErr(null);
     setLoading(true);
@@ -368,6 +368,7 @@ export default function TrustPage() {
 
   async function onReport(e: React.FormEvent) {
     e.preventDefault();
+    if (loading) return;
     if (!token) return;
     setMsg(null);
     setErr(null);
@@ -390,6 +391,7 @@ export default function TrustPage() {
 
   async function onPeerReview(e: React.FormEvent) {
     e.preventDefault();
+    if (loading) return;
     if (!token) return;
     setMsg(null);
     setErr(null);

--- a/webapp/e2e/trust.visual.spec.ts
+++ b/webapp/e2e/trust.visual.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("trust page interactions", () => {
+  test.beforeEach(async () => {
+    test.skip(
+      process.env.E2E_API_BASE === undefined,
+      "Requires running webapp/edge environment",
+    );
+  });
+  test("reputation lookup success", async ({ page }) => {
+    await page.route("**/api/trust/reputation*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ user_id: "123", score: 5 }),
+      });
+    });
+
+    await page.goto("/trust");
+
+    await page.getByPlaceholder("user UUID").fill("123");
+    await page.getByTestId("trust-reputation-submit").click();
+
+    await expect(page.getByText(/Reputation for/)).toBeVisible();
+  });
+
+  test("reputation lookup error", async ({ page }) => {
+    await page.route("**/api/trust/reputation*", async (route) => {
+      await route.fulfill({
+        status: 500,
+        body: JSON.stringify({ error: "fail" }),
+      });
+    });
+
+    await page.goto("/trust");
+
+    await page.getByPlaceholder("user UUID").fill("123");
+    await page.getByTestId("trust-reputation-submit").click();
+
+    await expect(page.getByRole("alert")).toBeVisible();
+  });
+
+  test("feedback resets on new action", async ({ page }) => {
+    let first = true;
+
+    await page.route("**/api/trust/reputation*", async (route) => {
+      if (first) {
+        first = false;
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify({ user_id: "123", score: 5 }),
+        });
+      } else {
+        await route.fulfill({
+          status: 500,
+          body: JSON.stringify({ error: "fail" }),
+        });
+      }
+    });
+
+    await page.goto("/trust");
+
+    const input = page.getByPlaceholder("user UUID");
+    const submit = page.getByTestId("trust-reputation-submit");
+
+    await input.fill("123");
+    await submit.click();
+
+    await expect(page.getByText(/Reputation for/)).toBeVisible();
+
+    // second action → should clear success and show error
+    await submit.click();
+
+    await expect(page.getByRole("alert")).toBeVisible();
+  });
+});

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -33,6 +33,7 @@ const suiteProjects = [
       "guest.spec.ts",
       "webapp-pages.spec.ts",
       "messaging-mentioned.spec.ts",
+      "trust.visual.spec.ts",
     ],
   },
   {


### PR DESCRIPTION
## Summary

Redesigns the Trust page to improve layout, clarity of moderation actions, and overall UX consistency with the listings and homepage redesign.

## What changed

- Updated page layout and visual hierarchy to match current design patterns
- Extracted page into local sections:
  - TrustHeaderSection
  - ReputationSection
  - ReportAbuseSection
  - PeerReviewSection
  - TrustLoginPrompt
  - TrustFeedback
- Improved feedback states:
  - styled success/error messages
  - clearer loading states on actions
  - disabled + loading-aware buttons
- Minor UX improvements:
  - consistent spacing and card styling
  - cleared stale feedback on new actions

## Scope

- `webapp/app/trust/page.tsx`
- No backend/API changes

## Notes

- Follows patterns established in listings page redesign
- Keeps UI components local (no shared UI extraction yet)

Closes #84