### PR TITLE
feat(booking-service): add dry-run validation endpoint for booking creation

### DIFF
--- a/services/booking-service/src/http-app.ts
+++ b/services/booking-service/src/http-app.ts
@@ -111,13 +111,11 @@ export function createBookingHttpApp(): Express {
       await prisma.$queryRaw`SELECT 1`;
       res.status(200).json({ ok: true, db: "connected" });
     } catch {
-      res
-        .status(200)
-        .json({
-          ok: true,
-          db: "disconnected",
-          warning: "database unavailable",
-        });
+      res.status(200).json({
+        ok: true,
+        db: "disconnected",
+        warning: "database unavailable",
+      });
     }
   });
 
@@ -171,34 +169,32 @@ export function createBookingHttpApp(): Express {
         }
 
         if (parsedStartDate >= parsedEndDate) {
-          const overlappingBooking = await prisma.booking.findFirst({
-            where: {
-              listingId,
-              status: {
-                not: "cancelled",
-              },
-              AND: [
-                {
-                  startDate: {
-                    lt: parsedEndDate,
-                  },
-                },
-                {
-                  endDate: {
-                    gt: parsedStartDate,
-                  },
-                },
-              ],
-            },
+          res.status(400).json({
+            valid: false,
+            error: "startDate must be before endDate",
           });
+          return;
+        }
 
-          if (overlappingBooking) {
-            res.status(409).json({
-              valid: false,
-              error: "Booking dates overlap with an existing booking",
-            });
-            return;
-          }
+        const overlappingBooking = await prisma.booking.findFirst({
+          where: {
+            listingId,
+            status: {
+              not: "cancelled",
+            },
+            AND: [
+              { startDate: { lt: parsedEndDate } },
+              { endDate: { gt: parsedStartDate } },
+            ],
+          },
+        });
+
+        if (overlappingBooking) {
+          res.status(409).json({
+            valid: false,
+            error: "Booking dates overlap with an existing booking",
+          });
+          return;
         }
 
         res.status(200).json({
@@ -570,11 +566,9 @@ export function createBookingHttpApp(): Express {
           return;
         }
         if (current.status === "cancelled" || current.status === "completed") {
-          res
-            .status(409)
-            .json({
-              error: "cannot edit tenant notes for terminal booking status",
-            });
+          res.status(409).json({
+            error: "cannot edit tenant notes for terminal booking status",
+          });
           return;
         }
 

--- a/services/booking-service/src/http-app.ts
+++ b/services/booking-service/src/http-app.ts
@@ -1,5 +1,15 @@
-import express, { type Express, type NextFunction, type Request, type Response } from "express";
-import { kafka, register, httpCounter, createHttpConcurrencyGuard } from "@common/utils";
+import express, {
+  type Express,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
+import {
+  kafka,
+  register,
+  httpCounter,
+  createHttpConcurrencyGuard,
+} from "@common/utils";
 import { Prisma } from "../prisma/generated/client/index.js";
 import { prisma } from "./lib/prisma.js";
 import { randomUUID } from "node:crypto";
@@ -54,7 +64,11 @@ async function publishBookingEvent(
   }
 }
 
-function requireUser(req: AuthedRequest, res: Response, next: NextFunction): void {
+function requireUser(
+  req: AuthedRequest,
+  res: Response,
+  next: NextFunction,
+): void {
   const userId = (req.get("x-user-id") || "").trim();
   if (!userId) {
     res.status(401).json({ error: "missing x-user-id" });
@@ -82,7 +96,12 @@ export function createBookingHttpApp(): Express {
 
   app.use((req, res, next) => {
     res.on("finish", () =>
-      httpCounter.inc({ service: "booking", route: req.path, method: req.method, code: res.statusCode }),
+      httpCounter.inc({
+        service: "booking",
+        route: req.path,
+        method: req.method,
+        code: res.statusCode,
+      }),
     );
     next();
   });
@@ -92,7 +111,13 @@ export function createBookingHttpApp(): Express {
       await prisma.$queryRaw`SELECT 1`;
       res.status(200).json({ ok: true, db: "connected" });
     } catch {
-      res.status(200).json({ ok: true, db: "disconnected", warning: "database unavailable" });
+      res
+        .status(200)
+        .json({
+          ok: true,
+          db: "disconnected",
+          warning: "database unavailable",
+        });
     }
   });
 
@@ -109,376 +134,490 @@ export function createBookingHttpApp(): Express {
     }),
   );
 
-  app.post("/dry-run", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const { listingId, startDate, endDate, landlordId, priceCents } = req.body as {
-        listingId?: string;
-        startDate?: string;
-        endDate?: string;
-        landlordId?: string;
-        priceCents?: number;
-      };
+  app.post(
+    "/dry-run",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const { listingId, startDate, endDate, landlordId, priceCents } =
+          req.body as {
+            listingId?: string;
+            startDate?: string;
+            endDate?: string;
+            landlordId?: string;
+            priceCents?: number;
+          };
 
-      if (!listingId || !startDate || !endDate || !req.userId) {
-        res.status(400).json({
-          valid: false,
-          error: "listingId, startDate, endDate required",
+        if (!listingId || !startDate || !endDate || !req.userId) {
+          res.status(400).json({
+            valid: false,
+            error: "listingId, startDate, endDate required",
+          });
+          return;
+        }
+
+        const parsedStartDate = new Date(startDate);
+        const parsedEndDate = new Date(endDate);
+
+        if (
+          Number.isNaN(parsedStartDate.getTime()) ||
+          Number.isNaN(parsedEndDate.getTime())
+        ) {
+          res.status(400).json({
+            valid: false,
+            error: "startDate and endDate must be valid dates",
+          });
+          return;
+        }
+
+        if (parsedStartDate >= parsedEndDate) {
+          const overlappingBooking = await prisma.booking.findFirst({
+            where: {
+              listingId,
+              status: {
+                not: "cancelled",
+              },
+              AND: [
+                {
+                  startDate: {
+                    lt: parsedEndDate,
+                  },
+                },
+                {
+                  endDate: {
+                    gt: parsedStartDate,
+                  },
+                },
+              ],
+            },
+          });
+
+          if (overlappingBooking) {
+            res.status(409).json({
+              valid: false,
+              error: "Booking dates overlap with an existing booking",
+            });
+            return;
+          }
+        }
+
+        res.status(200).json({
+          valid: true,
+          message: "Booking request is valid",
+          bookingPreview: {
+            listingId,
+            tenantId: req.userId,
+            landlordId: landlordId || req.userId,
+            status: "created",
+            startDate: parsedStartDate.toISOString(),
+            endDate: parsedEndDate.toISOString(),
+            priceCentsSnapshot: Number.isFinite(priceCents)
+              ? Number(priceCents)
+              : 0,
+            currencyCode: "USD",
+          },
         });
-        return;
+      } catch (error) {
+        console.error("[booking] dry-run failed", error);
+        res.status(500).json({ valid: false, error: "internal" });
       }
+    },
+  );
 
-      const parsedStartDate = new Date(startDate);
-      const parsedEndDate = new Date(endDate);
+  app.post(
+    "/create",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const { listingId, startDate, endDate, landlordId, priceCents } =
+          req.body as {
+            listingId?: string;
+            startDate?: string;
+            endDate?: string;
+            landlordId?: string;
+            priceCents?: number;
+          };
+        if (!listingId || !startDate || !endDate || !req.userId) {
+          res
+            .status(400)
+            .json({ error: "listingId, startDate, endDate required" });
+          return;
+        }
 
-      if (Number.isNaN(parsedStartDate.getTime()) || Number.isNaN(parsedEndDate.getTime())) {
-        res.status(400).json({
-          valid: false,
-          error: "startDate and endDate must be valid dates",
+        const booking = await prisma.booking.create({
+          data: {
+            listingId,
+            tenantId: req.userId,
+            landlordId: landlordId || req.userId,
+            status: "created" as const,
+            startDate: new Date(startDate),
+            endDate: new Date(endDate),
+            priceCentsSnapshot: Number.isFinite(priceCents)
+              ? Number(priceCents)
+              : 0,
+            currencyCode: "USD",
+          },
         });
-        return;
-      }
 
-      if (parsedStartDate >= parsedEndDate) {
-        res.status(400).json({
-          valid: false,
-          error: "startDate must be before endDate",
+        await publishBookingEvent("BookingCreatedV1", booking.id, {
+          booking_id: booking.id,
+          listing_id: booking.listingId,
+          tenant_id: booking.tenantId,
+          start_date: booking.startDate.toISOString(),
+          end_date: booking.endDate.toISOString(),
         });
-        return;
+
+        res.status(201).json(booking);
+      } catch (error) {
+        console.error("[booking] create failed", error);
+        res.status(500).json({ error: "internal" });
       }
+    },
+  );
 
-      res.status(200).json({
-        valid: true,
-        message: "Booking request is valid",
-        bookingPreview: {
-          listingId,
-          tenantId: req.userId,
-          landlordId: landlordId || req.userId,
-          status: "created",
-          startDate: parsedStartDate.toISOString(),
-          endDate: parsedEndDate.toISOString(),
-          priceCentsSnapshot: Number.isFinite(priceCents) ? Number(priceCents) : 0,
-          currencyCode: "USD",
-        },
-      });
-    } catch (error) {
-      console.error("[booking] dry-run failed", error);
-      res.status(500).json({ valid: false, error: "internal" });
-    }
-  });
+  app.post(
+    "/confirm",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const { bookingId, landlordId } = req.body as {
+          bookingId?: string;
+          landlordId?: string;
+        };
+        if (!bookingId) {
+          res.status(400).json({ error: "bookingId required" });
+          return;
+        }
 
-  app.post("/create", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const { listingId, startDate, endDate, landlordId, priceCents } = req.body as {
-        listingId?: string;
-        startDate?: string;
-        endDate?: string;
-        landlordId?: string;
-        priceCents?: number;
-      };
-      if (!listingId || !startDate || !endDate || !req.userId) {
-        res.status(400).json({ error: "listingId, startDate, endDate required" });
-        return;
+        const current = await prisma.booking.findUnique({
+          where: { id: bookingId },
+        });
+        if (!current) {
+          res.status(404).json({ error: "booking not found" });
+          return;
+        }
+        if (
+          current.status !== "created" &&
+          current.status !== "pending_confirmation"
+        ) {
+          res
+            .status(409)
+            .json({ error: `cannot confirm from status ${current.status}` });
+          return;
+        }
+
+        const landlord = landlordId || current.landlordId;
+        await prisma.booking.update({
+          where: { id: bookingId },
+          data: { status: "pending_confirmation" as const },
+        });
+        const updated = await prisma.booking.update({
+          where: { id: bookingId },
+          data: {
+            status: "confirmed" as const,
+            landlordId: landlord,
+            confirmedAt: new Date(),
+          },
+        });
+
+        await publishBookingEvent("BookingConfirmedV1", updated.id, {
+          booking_id: updated.id,
+          listing_id: updated.listingId,
+          tenant_id: updated.tenantId,
+          landlord_id: updated.landlordId || "",
+        });
+
+        res.json(updated);
+      } catch (error) {
+        console.error("[booking] confirm failed", error);
+        res.status(500).json({ error: "internal" });
       }
+    },
+  );
 
-      const booking = await prisma.booking.create({
-        data: {
-          listingId,
-          tenantId: req.userId,
-          landlordId: landlordId || req.userId,
-          status: "created" as const,
-          startDate: new Date(startDate),
-          endDate: new Date(endDate),
-          priceCentsSnapshot: Number.isFinite(priceCents) ? Number(priceCents) : 0,
-          currencyCode: "USD",
-        },
-      });
+  app.post(
+    "/cancel",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const { bookingId, cancelledBy } = req.body as {
+          bookingId?: string;
+          cancelledBy?: string;
+        };
+        if (!bookingId) {
+          res.status(400).json({ error: "bookingId required" });
+          return;
+        }
+        const actor = cancelledBy || (req.userId ? "tenant" : "unknown");
+        const current = await prisma.booking.findUnique({
+          where: { id: bookingId },
+        });
+        if (!current) {
+          res.status(404).json({ error: "booking not found" });
+          return;
+        }
+        if (
+          current.tenantId !== req.userId &&
+          current.landlordId !== req.userId
+        ) {
+          res.status(403).json({ error: "forbidden" });
+          return;
+        }
+        if (current.status === "cancelled") {
+          res.status(409).json({ error: "booking already cancelled" });
+          return;
+        }
 
-      await publishBookingEvent("BookingCreatedV1", booking.id, {
-        booking_id: booking.id,
-        listing_id: booking.listingId,
-        tenant_id: booking.tenantId,
-        start_date: booking.startDate.toISOString(),
-        end_date: booking.endDate.toISOString(),
-      });
+        const updated = await prisma.booking.update({
+          where: { id: bookingId },
+          data: {
+            status: "cancelled" as const,
+            cancellationReason: `cancelled_by:${actor}`,
+            cancelledAt: new Date(),
+          },
+        });
 
-      res.status(201).json(booking);
-    } catch (error) {
-      console.error("[booking] create failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
+        await publishBookingEvent("BookingCancelledV1", updated.id, {
+          booking_id: updated.id,
+          listing_id: updated.listingId,
+          cancelled_by: actor,
+        });
 
-  app.post("/confirm", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const { bookingId, landlordId } = req.body as { bookingId?: string; landlordId?: string };
-      if (!bookingId) {
-        res.status(400).json({ error: "bookingId required" });
-        return;
+        res.json(updated);
+      } catch (error) {
+        console.error("[booking] cancel failed", error);
+        res.status(500).json({ error: "internal" });
       }
+    },
+  );
 
-      const current = await prisma.booking.findUnique({ where: { id: bookingId } });
-      if (!current) {
-        res.status(404).json({ error: "booking not found" });
-        return;
+  app.post(
+    "/search-history",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        disableHistoryCaching(res);
+        const {
+          query,
+          minPriceCents,
+          maxPriceCents,
+          maxDistanceKm,
+          latitude,
+          longitude,
+          filters,
+        } = req.body as {
+          query?: string;
+          minPriceCents?: number;
+          maxPriceCents?: number;
+          maxDistanceKm?: number;
+          latitude?: number;
+          longitude?: number;
+          filters?: Record<string, unknown>;
+        };
+        const row = await prisma.searchHistory.create({
+          data: {
+            userId: req.userId!,
+            query: query || null,
+            minPriceCents: minPriceCents ?? null,
+            maxPriceCents: maxPriceCents ?? null,
+            maxDistanceKm: maxDistanceKm ?? null,
+            latitude: latitude ?? null,
+            longitude: longitude ?? null,
+            filters:
+              (filters as Prisma.InputJsonValue | undefined) ?? undefined,
+          },
+        });
+        res.status(201).json(row);
+      } catch (error) {
+        console.error("[booking] search-history create failed", error);
+        res.status(500).json({ error: "internal" });
       }
-      if (current.status !== "created" && current.status !== "pending_confirmation") {
-        res.status(409).json({ error: `cannot confirm from status ${current.status}` });
-        return;
+    },
+  );
+
+  app.get(
+    "/search-history/list",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        disableHistoryCaching(res);
+        const limit = Math.min(Number(req.query.limit || 25), 100);
+        const items = await prisma.searchHistory.findMany({
+          where: { userId: req.userId! },
+          orderBy: { createdAt: "desc" },
+          take: limit,
+        });
+        res.json({ items });
+      } catch (error) {
+        console.error("[booking] search-history list failed", error);
+        res.status(500).json({ error: "internal" });
       }
+    },
+  );
 
-      const landlord = landlordId || current.landlordId;
-      await prisma.booking.update({
-        where: { id: bookingId },
-        data: { status: "pending_confirmation" as const },
-      });
-      const updated = await prisma.booking.update({
-        where: { id: bookingId },
-        data: {
-          status: "confirmed" as const,
-          landlordId: landlord,
-          confirmedAt: new Date(),
-        },
-      });
-
-      await publishBookingEvent("BookingConfirmedV1", updated.id, {
-        booking_id: updated.id,
-        listing_id: updated.listingId,
-        tenant_id: updated.tenantId,
-        landlord_id: updated.landlordId || "",
-      });
-
-      res.json(updated);
-    } catch (error) {
-      console.error("[booking] confirm failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
-
-  app.post("/cancel", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const { bookingId, cancelledBy } = req.body as { bookingId?: string; cancelledBy?: string };
-      if (!bookingId) {
-        res.status(400).json({ error: "bookingId required" });
-        return;
-      }
-      const actor = cancelledBy || (req.userId ? "tenant" : "unknown");
-      const current = await prisma.booking.findUnique({ where: { id: bookingId } });
-      if (!current) {
-        res.status(404).json({ error: "booking not found" });
-        return;
-      }
-      if (current.tenantId !== req.userId && current.landlordId !== req.userId) {
-        res.status(403).json({ error: "forbidden" });
-        return;
-      }
-      if (current.status === "cancelled") {
-        res.status(409).json({ error: "booking already cancelled" });
-        return;
-      }
-
-      const updated = await prisma.booking.update({
-        where: { id: bookingId },
-        data: {
-          status: "cancelled" as const,
-          cancellationReason: `cancelled_by:${actor}`,
-          cancelledAt: new Date(),
-        },
-      });
-
-      await publishBookingEvent("BookingCancelledV1", updated.id, {
-        booking_id: updated.id,
-        listing_id: updated.listingId,
-        cancelled_by: actor,
-      });
-
-      res.json(updated);
-    } catch (error) {
-      console.error("[booking] cancel failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
-
-  app.post("/search-history", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      disableHistoryCaching(res);
-      const { query, minPriceCents, maxPriceCents, maxDistanceKm, latitude, longitude, filters } = req.body as {
-        query?: string;
-        minPriceCents?: number;
-        maxPriceCents?: number;
-        maxDistanceKm?: number;
-        latitude?: number;
-        longitude?: number;
-        filters?: Record<string, unknown>;
-      };
-      const row = await prisma.searchHistory.create({
-        data: {
-          userId: req.userId!,
-          query: query || null,
-          minPriceCents: minPriceCents ?? null,
-          maxPriceCents: maxPriceCents ?? null,
-          maxDistanceKm: maxDistanceKm ?? null,
-          latitude: latitude ?? null,
-          longitude: longitude ?? null,
-          filters: (filters as Prisma.InputJsonValue | undefined) ?? undefined,
-        },
-      });
-      res.status(201).json(row);
-    } catch (error) {
-      console.error("[booking] search-history create failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
-
-  app.get("/search-history/list", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      disableHistoryCaching(res);
-      const limit = Math.min(Number(req.query.limit || 25), 100);
-      const items = await prisma.searchHistory.findMany({
-        where: { userId: req.userId! },
-        orderBy: { createdAt: "desc" },
-        take: limit,
-      });
-      res.json({ items });
-    } catch (error) {
-      console.error("[booking] search-history list failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
-
-  app.post("/watchlist/add", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const { listingId, source } = req.body as { listingId?: string; source?: string };
-      if (!listingId) {
-        res.status(400).json({ error: "listingId required" });
-        return;
-      }
-      const item = await prisma.watchlistItem.upsert({
-        where: {
-          userId_listingId: {
+  app.post(
+    "/watchlist/add",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const { listingId, source } = req.body as {
+          listingId?: string;
+          source?: string;
+        };
+        if (!listingId) {
+          res.status(400).json({ error: "listingId required" });
+          return;
+        }
+        const item = await prisma.watchlistItem.upsert({
+          where: {
+            userId_listingId: {
+              userId: req.userId!,
+              listingId,
+            },
+          },
+          update: {
+            isActive: true,
+            removedAt: null,
+            source: source ?? null,
+          },
+          create: {
             userId: req.userId!,
             listingId,
+            source: source ?? null,
+            isActive: true,
           },
-        },
-        update: {
-          isActive: true,
-          removedAt: null,
-          source: source ?? null,
-        },
-        create: {
-          userId: req.userId!,
-          listingId,
-          source: source ?? null,
-          isActive: true,
-        },
-      });
-      res.status(201).json(item);
-    } catch (error) {
-      console.error("[booking] watchlist add failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
+        });
+        res.status(201).json(item);
+      } catch (error) {
+        console.error("[booking] watchlist add failed", error);
+        res.status(500).json({ error: "internal" });
+      }
+    },
+  );
 
-  app.post("/watchlist/remove", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const { listingId } = req.body as { listingId?: string };
-      if (!listingId) {
-        res.status(400).json({ error: "listingId required" });
-        return;
+  app.post(
+    "/watchlist/remove",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const { listingId } = req.body as { listingId?: string };
+        if (!listingId) {
+          res.status(400).json({ error: "listingId required" });
+          return;
+        }
+        const updated = await prisma.watchlistItem.updateMany({
+          where: { userId: req.userId!, listingId, isActive: true },
+          data: { isActive: false, removedAt: new Date() },
+        });
+        res.json({
+          ok: true,
+          removed: updated.count,
+          message: "Removed from watchlist",
+        });
+      } catch (error) {
+        console.error("[booking] watchlist remove failed", error);
+        res.status(500).json({ error: "internal" });
       }
-      const updated = await prisma.watchlistItem.updateMany({
-        where: { userId: req.userId!, listingId, isActive: true },
-        data: { isActive: false, removedAt: new Date() },
-      });
-      res.json({
-        ok: true,
-        removed: updated.count,
-        message: "Removed from watchlist",
-      });
-    } catch (error) {
-      console.error("[booking] watchlist remove failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
+    },
+  );
 
-  app.get("/watchlist/list", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const items = await prisma.watchlistItem.findMany({
-        where: { userId: req.userId!, isActive: true },
-        orderBy: { addedAt: "desc" },
-      });
-      res.json({ items });
-    } catch (error) {
-      console.error("[booking] watchlist list failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
+  app.get(
+    "/watchlist/list",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const items = await prisma.watchlistItem.findMany({
+          where: { userId: req.userId!, isActive: true },
+          orderBy: { addedAt: "desc" },
+        });
+        res.json({ items });
+      } catch (error) {
+        console.error("[booking] watchlist list failed", error);
+        res.status(500).json({ error: "internal" });
+      }
+    },
+  );
 
-  app.patch("/:bookingId", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const bid = req.params.bookingId || "";
-      if (!UUID_RE.test(bid)) {
-        res.status(400).json({ error: "invalid bookingId" });
-        return;
-      }
-      const { tenantNotes } = req.body as { tenantNotes?: string | null };
-      if (!Object.prototype.hasOwnProperty.call(req.body, "tenantNotes")) {
-        res.status(400).json({ error: "tenantNotes required (string or null)" });
-        return;
-      }
-      if (tenantNotes !== null && typeof tenantNotes !== "string") {
-        res.status(400).json({ error: "tenantNotes must be string or null" });
-        return;
-      }
+  app.patch(
+    "/:bookingId",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const bid = req.params.bookingId || "";
+        if (!UUID_RE.test(bid)) {
+          res.status(400).json({ error: "invalid bookingId" });
+          return;
+        }
+        const { tenantNotes } = req.body as { tenantNotes?: string | null };
+        if (!Object.prototype.hasOwnProperty.call(req.body, "tenantNotes")) {
+          res
+            .status(400)
+            .json({ error: "tenantNotes required (string or null)" });
+          return;
+        }
+        if (tenantNotes !== null && typeof tenantNotes !== "string") {
+          res.status(400).json({ error: "tenantNotes must be string or null" });
+          return;
+        }
 
-      const current = await prisma.booking.findUnique({ where: { id: bid } });
-      if (!current) {
-        res.status(404).json({ error: "booking not found" });
-        return;
-      }
-      if (current.tenantId !== req.userId) {
-        res.status(403).json({ error: "forbidden" });
-        return;
-      }
-      if (current.status === "cancelled" || current.status === "completed") {
-        res.status(409).json({ error: "cannot edit tenant notes for terminal booking status" });
-        return;
-      }
+        const current = await prisma.booking.findUnique({ where: { id: bid } });
+        if (!current) {
+          res.status(404).json({ error: "booking not found" });
+          return;
+        }
+        if (current.tenantId !== req.userId) {
+          res.status(403).json({ error: "forbidden" });
+          return;
+        }
+        if (current.status === "cancelled" || current.status === "completed") {
+          res
+            .status(409)
+            .json({
+              error: "cannot edit tenant notes for terminal booking status",
+            });
+          return;
+        }
 
-      const trimmed =
-        tenantNotes === null ? null : tenantNotes.slice(0, TENANT_NOTES_MAX);
-      const updated = await prisma.booking.update({
-        where: { id: current.id },
-        data: { tenantNotes: trimmed },
-      });
-      res.json(updated);
-    } catch (error) {
-      console.error("[booking] patch tenant notes failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
+        const trimmed =
+          tenantNotes === null ? null : tenantNotes.slice(0, TENANT_NOTES_MAX);
+        const updated = await prisma.booking.update({
+          where: { id: current.id },
+          data: { tenantNotes: trimmed },
+        });
+        res.json(updated);
+      } catch (error) {
+        console.error("[booking] patch tenant notes failed", error);
+        res.status(500).json({ error: "internal" });
+      }
+    },
+  );
 
-  app.get("/:bookingId", requireUser, async (req: AuthedRequest, res: Response) => {
-    try {
-      const bid = req.params.bookingId || "";
-      if (!UUID_RE.test(bid)) {
-        res.status(400).json({ error: "invalid bookingId" });
-        return;
+  app.get(
+    "/:bookingId",
+    requireUser,
+    async (req: AuthedRequest, res: Response) => {
+      try {
+        const bid = req.params.bookingId || "";
+        if (!UUID_RE.test(bid)) {
+          res.status(400).json({ error: "invalid bookingId" });
+          return;
+        }
+        const booking = await prisma.booking.findUnique({ where: { id: bid } });
+        if (!booking) {
+          res.status(404).json({ error: "booking not found" });
+          return;
+        }
+        if (booking.tenantId !== req.userId) {
+          res.status(403).json({ error: "forbidden" });
+          return;
+        }
+        res.json(booking);
+      } catch (error) {
+        console.error("[booking] get failed", error);
+        res.status(500).json({ error: "internal" });
       }
-      const booking = await prisma.booking.findUnique({ where: { id: bid } });
-      if (!booking) {
-        res.status(404).json({ error: "booking not found" });
-        return;
-      }
-      if (booking.tenantId !== req.userId) {
-        res.status(403).json({ error: "forbidden" });
-        return;
-      }
-      res.json(booking);
-    } catch (error) {
-      console.error("[booking] get failed", error);
-      res.status(500).json({ error: "internal" });
-    }
-  });
+    },
+  );
 
   return app;
 }

--- a/services/booking-service/src/http-app.ts
+++ b/services/booking-service/src/http-app.ts
@@ -109,6 +109,63 @@ export function createBookingHttpApp(): Express {
     }),
   );
 
+  app.post("/dry-run", requireUser, async (req: AuthedRequest, res: Response) => {
+    try {
+      const { listingId, startDate, endDate, landlordId, priceCents } = req.body as {
+        listingId?: string;
+        startDate?: string;
+        endDate?: string;
+        landlordId?: string;
+        priceCents?: number;
+      };
+
+      if (!listingId || !startDate || !endDate || !req.userId) {
+        res.status(400).json({
+          valid: false,
+          error: "listingId, startDate, endDate required",
+        });
+        return;
+      }
+
+      const parsedStartDate = new Date(startDate);
+      const parsedEndDate = new Date(endDate);
+
+      if (Number.isNaN(parsedStartDate.getTime()) || Number.isNaN(parsedEndDate.getTime())) {
+        res.status(400).json({
+          valid: false,
+          error: "startDate and endDate must be valid dates",
+        });
+        return;
+      }
+
+      if (parsedStartDate >= parsedEndDate) {
+        res.status(400).json({
+          valid: false,
+          error: "startDate must be before endDate",
+        });
+        return;
+      }
+
+      res.status(200).json({
+        valid: true,
+        message: "Booking request is valid",
+        bookingPreview: {
+          listingId,
+          tenantId: req.userId,
+          landlordId: landlordId || req.userId,
+          status: "created",
+          startDate: parsedStartDate.toISOString(),
+          endDate: parsedEndDate.toISOString(),
+          priceCentsSnapshot: Number.isFinite(priceCents) ? Number(priceCents) : 0,
+          currencyCode: "USD",
+        },
+      });
+    } catch (error) {
+      console.error("[booking] dry-run failed", error);
+      res.status(500).json({ valid: false, error: "internal" });
+    }
+  });
+
   app.post("/create", requireUser, async (req: AuthedRequest, res: Response) => {
     try {
       const { listingId, startDate, endDate, landlordId, priceCents } = req.body as {

--- a/services/booking-service/src/http-app.ts
+++ b/services/booking-service/src/http-app.ts
@@ -154,6 +154,22 @@ export function createBookingHttpApp(): Express {
           return;
         }
 
+        if (!UUID_RE.test(listingId)) {
+          res.status(400).json({
+            valid: false,
+            error: "listingId must be a valid UUID",
+          });
+          return;
+        }
+
+        if (landlordId && !UUID_RE.test(landlordId)) {
+          res.status(400).json({
+            valid: false,
+            error: "landlordId must be a valid UUID",
+          });
+          return;
+        }
+
         const parsedStartDate = new Date(startDate);
         const parsedEndDate = new Date(endDate);
 


### PR DESCRIPTION
## What this PR does

Adds a validation-only dry-run endpoint to the booking service to verify booking requests before creating a database record.

## Changes made

### 1. Add `POST /dry-run` endpoint
- New route in `booking-service/src/http-app.ts`
- Protected with `requireUser` middleware
- Returns validation result and booking preview

### 2. Input validation
- Validates required fields: `listingId`, `startDate`, `endDate`
- Validates UUID format for `listingId` and optional `landlordId`
- Ensures `startDate` and `endDate` are valid dates

### 3. Booking rules validation
- Ensures `startDate < endDate`
- Checks for overlapping bookings against existing non-cancelled bookings

### 4. No database writes
- Returns a `bookingPreview` object for valid requests
- Does not insert any booking into the database
- No schema or migration changes required

## Why

Clients may need to validate booking requests (dates, conflicts, formatting) before attempting creation. This endpoint reduces failed writes and improves UX by providing early feedback.

## Fixes

- Supports #70 (validation-only endpoints)