### PR TITLE
fix(webapp): improve trust page accessibility (labels, aria semantics, feedback)

### DIFF
--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -53,7 +53,14 @@ function ReputationSection({
         aria-busy={loading}
         className="mt-4 flex flex-col gap-3 sm:flex-row"
       >
+        <label
+          htmlFor="trust-reputation-user-id"
+          className="sr-only"
+        >
+          User UUID
+        </label>
         <input
+          id="trust-reputation-user-id"
           data-testid="trust-reputation-user-id"
           value={repUserId}
           onChange={(e) => setRepUserId(e.target.value)}
@@ -146,20 +153,41 @@ function ReportAbuseSection({
             User
           </label>
         </div>
+        <label
+          htmlFor="trust-abuse-target"
+          className="sr-only"
+        >
+          Target UUID
+        </label>
         <input
+          id="trust-abuse-target"
           value={abuseTarget}
           onChange={(e) => setAbuseTarget(e.target.value)}
           placeholder="target UUID"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
           required
         />
+        <label
+          htmlFor="trust-abuse-category"
+          className="sr-only"
+        >
+          Abuse category
+        </label>
         <input
+          id="trust-abuse-category"
           value={abuseCategory}
           onChange={(e) => setAbuseCategory(e.target.value)}
           placeholder="category"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
         />
+        <label
+          htmlFor="trust-abuse-details"
+          className="sr-only"
+        >
+          Abuse details
+        </label>
         <textarea
+          id="trust-abuse-details"
           value={abuseDetails}
           onChange={(e) => setAbuseDetails(e.target.value)}
           placeholder="details (optional)"
@@ -222,29 +250,56 @@ function PeerReviewSection({
         aria-busy={loading}
         className="mt-4 space-y-3"
       >
+        <label
+          htmlFor="trust-booking-id"
+          className="sr-only"
+        >
+          Booking UUID
+        </label>
         <input
+          id="trust-booking-id"
           value={bookingId}
           onChange={(e) => setBookingId(e.target.value)}
           placeholder="booking UUID"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
           required
         />
+        <label
+          htmlFor="trust-reviewee-id"
+          className="sr-only"
+        >
+          Reviewee user UUID
+        </label>
         <input
+          id="trust-reviewee-id"
           value={revieweeId}
           onChange={(e) => setRevieweeId(e.target.value)}
           placeholder="reviewee user UUID"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm"
           required
         />
+        <label
+          htmlFor="trust-review-side"
+          className="sr-only"
+        >
+          Review side
+        </label>
         <input
+          id="trust-review-side"
           value={side}
           onChange={(e) => setSide(e.target.value)}
           placeholder="side label e.g. guest | host"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm"
         />
         <div>
-          <label className="text-xs text-slate-600">Rating 1–5</label>
+          <label
+            htmlFor="trust-review-rating"
+            className="text-xs text-slate-600"
+          >
+            Rating 1–5
+          </label>
           <input
+            id="trust-review-rating"
             type="number"
             min={1}
             max={5}
@@ -253,7 +308,14 @@ function PeerReviewSection({
             className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm"
           />
         </div>
+        <label
+          htmlFor="trust-review-comment"
+          className="sr-only"
+        >
+          Review comment
+        </label>
         <textarea
+          id="trust-review-comment"
           value={comment}
           onChange={(e) => setComment(e.target.value)}
           placeholder="comment"

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -366,6 +366,7 @@ function TrustFeedback({
       <div
         role="status"
         aria-live="polite"
+        aria-atomic="true"
         className="mt-6 rounded-[1.25rem] border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800 shadow-sm"
       >
         {feedback.message}
@@ -376,6 +377,7 @@ function TrustFeedback({
   return (
     <div
       role="alert"
+      aria-atomic="true"
       className="mt-4 rounded-[1.25rem] border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-700 shadow-sm"
     >
       {feedback.message}

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -70,6 +70,7 @@ function ReputationSection({
         <button
           type="submit"
           disabled={loading}
+          aria-disabled={loading}
           data-testid="trust-reputation-submit"
           className="rounded-md bg-teal-600 px-4 py-2 font-medium text-white hover:bg-teal-500 disabled:opacity-50"
         >
@@ -133,7 +134,9 @@ function ReportAbuseSection({
         aria-busy={loading}
         className="mt-4 space-y-3"
       >
-        <div className="flex gap-4 text-sm text-slate-700">
+        <fieldset className="flex gap-4 text-sm text-slate-700">
+          <legend className="sr-only">Abuse target type</legend>
+
           <label className="flex items-center gap-2">
             <input
               type="radio"
@@ -143,6 +146,7 @@ function ReportAbuseSection({
             />
             Listing
           </label>
+
           <label className="flex items-center gap-2">
             <input
               type="radio"
@@ -152,7 +156,7 @@ function ReportAbuseSection({
             />
             User
           </label>
-        </div>
+        </fieldset>
         <label
           htmlFor="trust-abuse-target"
           className="sr-only"
@@ -197,6 +201,7 @@ function ReportAbuseSection({
         <button
           type="submit"
           disabled={loading}
+          aria-disabled={loading}
           className="rounded-md border border-red-200 bg-red-50 px-4 py-2 font-medium text-red-800 hover:bg-red-100 disabled:opacity-50"
         >
           {loading ? "Submitting report…" : "Submit report"}
@@ -325,6 +330,7 @@ function PeerReviewSection({
         <button
           type="submit"
           disabled={loading}
+          aria-disabled={loading}
           className="rounded-md bg-slate-700 px-4 py-2 font-medium text-white hover:bg-slate-600 disabled:opacity-50"
         >
           {loading ? "Submitting review…" : "Submit review"}

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { getReputation, reportAbuse, submitPeerReview } from "@/lib/api";
 import { getStoredEmail, getStoredToken } from "@/lib/auth-storage";
@@ -356,17 +356,21 @@ function TrustLoginPrompt() {
 
 function TrustFeedback({
   feedback,
+  feedbackRef,
 }: {
   feedback: { type: "success" | "error" | null; message: string };
+  feedbackRef: React.RefObject<HTMLDivElement>;
 }) {
   if (!feedback.type) return null;
 
   if (feedback.type === "success") {
     return (
       <div
+        ref={feedbackRef}
         role="status"
         aria-live="polite"
         aria-atomic="true"
+        tabIndex={-1}
         className="mt-6 rounded-[1.25rem] border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-800 shadow-sm"
       >
         {feedback.message}
@@ -376,8 +380,10 @@ function TrustFeedback({
 
   return (
     <div
+      ref={feedbackRef}
       role="alert"
       aria-atomic="true"
+      tabIndex={-1}
       className="mt-4 rounded-[1.25rem] border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium text-red-700 shadow-sm"
     >
       {feedback.message}
@@ -415,6 +421,8 @@ export default function TrustPage() {
     message: "",
   });
 
+  const feedbackRef = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
     const t = getStoredToken();
     setToken(t);
@@ -423,6 +431,12 @@ export default function TrustPage() {
     setMySub(sub);
     if (sub) setRepUserId(sub);
   }, []);
+
+  useEffect(() => {
+    if (!feedback.type) return;
+
+    feedbackRef.current?.focus();
+  }, [feedback.type]);
 
   async function onReputation(e: React.FormEvent) {
     e.preventDefault();
@@ -552,7 +566,10 @@ export default function TrustPage() {
           <TrustLoginPrompt />
         )}
 
-        <TrustFeedback feedback={feedback} />
+        <TrustFeedback
+          feedback={feedback}
+          feedbackRef={feedbackRef}
+        />
       </main>
     </div>
   );

--- a/webapp/e2e/trust.visual.spec.ts
+++ b/webapp/e2e/trust.visual.spec.ts
@@ -21,7 +21,9 @@ test.describe("trust page interactions", () => {
     await page.getByPlaceholder("user UUID").fill("123");
     await page.getByTestId("trust-reputation-submit").click();
 
-    await expect(page.getByText(/Reputation for/)).toBeVisible();
+    const status = page.getByRole("status");
+    await expect(status).toBeVisible();
+    await expect(status).toContainText("Reputation for");
   });
 
   test("reputation lookup error", async ({ page }) => {
@@ -37,7 +39,9 @@ test.describe("trust page interactions", () => {
     await page.getByPlaceholder("user UUID").fill("123");
     await page.getByTestId("trust-reputation-submit").click();
 
-    await expect(page.getByRole("alert")).toBeVisible();
+    const alert = page.getByRole("alert");
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText("fail");
   });
 
   test("feedback resets on new action", async ({ page }) => {
@@ -66,11 +70,15 @@ test.describe("trust page interactions", () => {
     await input.fill("123");
     await submit.click();
 
-    await expect(page.getByText(/Reputation for/)).toBeVisible();
+    const status = page.getByRole("status");
+    await expect(status).toBeVisible();
+    await expect(status).toContainText("Reputation for");
 
     // second action → should clear success and show error
     await submit.click();
 
-    await expect(page.getByRole("alert")).toBeVisible();
+    const alert = page.getByRole("alert");
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText("fail");
   });
 });


### PR DESCRIPTION
## Summary

Improves accessibility of the Trust page by adding proper form labels, improving ARIA semantics, and ensuring feedback messages are announced correctly.

## Changes

### Form accessibility
- Added accessible labels (`label + htmlFor`) to all inputs and textareas
- Ensured inputs no longer rely solely on placeholders for context
- Linked rating label to its input using `htmlFor` / `id` so assistive technologies correctly associate them

### Semantic structure
- Replaced abuse type radio group wrapper with `<fieldset>` and `<legend>`
- Added `aria-disabled` to loading buttons for better assistive support

### Feedback accessibility
- Improved feedback announcements using `aria-live`
- Added `aria-atomic` to ensure full messages are read by screen readers

## Why

The Trust page includes multiple form-driven interactions (reputation lookup, abuse reporting, peer reviews). These changes ensure the page is usable for keyboard and screen reader users and aligns with accessibility best practices.

## Scope

- No visual changes
- No changes to business logic or API calls
- Focused purely on accessibility improvements

## Testing

- Existing Playwright tests pass
- Verified:
  - Forms are keyboard navigable
  - Inputs have accessible names
  - Feedback messages are properly announced
  
  Closes #119 