### PR TITLE
feat(webapp): redesign listings marketplace UX and add listing detail route

### DIFF
--- a/webapp/app/listings/[id]/not-found.tsx
+++ b/webapp/app/listings/[id]/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { Nav } from "@/components/Nav";
+
+export default function ListingNotFound() {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.14),_transparent_28%),linear-gradient(180deg,_#f8fffd_0%,_#ffffff_34%,_#f8fafc_100%)] text-slate-900">
+      <Nav />
+
+      <main className="mx-auto flex max-w-3xl flex-col items-center px-4 py-20 text-center sm:px-6">
+        <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+          Listing not found
+        </p>
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-slate-950">
+          We could not find that listing.
+        </h1>
+        <p className="mt-4 text-base leading-7 text-slate-600">
+          The listing may have been removed, or the link may be incorrect.
+        </p>
+        <Link
+          href="/listings"
+          className="mt-8 rounded-full bg-teal-700 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-teal-700/20 transition hover:bg-teal-600"
+        >
+          Back to listings
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/webapp/app/listings/[id]/page.tsx
+++ b/webapp/app/listings/[id]/page.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import { notFound, useParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import { getListing, type ListingJson } from "@/lib/api";
-import { getStoredEmail } from "@/lib/auth-storage";
+import {
+  analyzeListingFeel,
+  getListing,
+  watchlistAdd,
+  watchlistRemove,
+  type ListingJson,
+} from "@/lib/api";
+import { getStoredEmail, getStoredToken } from "@/lib/auth-storage";
 import { Nav } from "@/components/Nav";
 import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
 
@@ -33,6 +39,70 @@ function ListingDetailSkeleton() {
 }
 
 function ListingDetailPageContent({ listing }: { listing: ListingJson }) {
+  const [saved, setSaved] = useState(false);
+  const [saveLoading, setSaveLoading] = useState(false);
+
+  const [analysisLoading, setAnalysisLoading] = useState(false);
+  const [analysisText, setAnalysisText] = useState<string | null>(null);
+
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [feedbackError, setFeedbackError] = useState<string | null>(null);
+
+  const token = getStoredToken();
+
+  async function handleToggleSave() {
+    if (!token) {
+      setFeedbackError("You must be logged in to save listings.");
+      return;
+    }
+
+    setSaveLoading(true);
+    setFeedbackError(null);
+    setFeedbackMessage(null);
+
+    try {
+      if (saved) {
+        await watchlistRemove(token, listing.id);
+        setSaved(false);
+        setFeedbackMessage("Listing removed from watchlist.");
+      } else {
+        await watchlistAdd(token, listing.id);
+        setSaved(true);
+        setFeedbackMessage("Listing saved to watchlist.");
+      }
+    } catch (err: unknown) {
+      setFeedbackError(
+        err instanceof Error ? err.message : "Could not update watchlist.",
+      );
+    } finally {
+      setSaveLoading(false);
+    }
+  }
+
+  async function handleAnalyzeListing() {
+    setAnalysisLoading(true);
+    setFeedbackError(null);
+    setFeedbackMessage(null);
+
+    try {
+      const result = await analyzeListingFeel(token, {
+        title: listing.title,
+        description: listing.description ?? "",
+        price_cents: listing.price_cents,
+        audience: "renter",
+      });
+
+      setAnalysisText(result.analysis_text ?? "No analysis available.");
+      setFeedbackMessage("Listing analysis generated.");
+    } catch (err: unknown) {
+      setFeedbackError(
+        err instanceof Error ? err.message : "Could not analyze listing.",
+      );
+    } finally {
+      setAnalysisLoading(false);
+    }
+  }
+
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.14),_transparent_28%),linear-gradient(180deg,_#f8fffd_0%,_#ffffff_34%,_#f8fafc_100%)] text-slate-900">
       <Nav email={getStoredEmail()} />
@@ -134,36 +204,93 @@ function ListingDetailPageContent({ listing }: { listing: ListingJson }) {
             </p>
 
             <div className="mt-6 space-y-3">
-              <button
-                type="button"
-                disabled
-                className="w-full rounded-full bg-teal-700 px-5 py-3 text-sm font-semibold text-white opacity-60"
-              >
-                Save listing
-              </button>
-              <button
-                type="button"
-                disabled
-                className="w-full rounded-full border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-800 opacity-60"
-              >
-                Analyze listing
-              </button>
-              <Link
-                href={`/booking?listingId=${encodeURIComponent(listing.id)}`}
-                className="block w-full rounded-full border border-slate-300 bg-white px-5 py-3 text-center text-sm font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
-              >
-                Start booking
-              </Link>
-              <button
-                type="button"
-                disabled
-                className="w-full rounded-full border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-medium text-slate-500"
-              >
-                Message landlord — coming soon
-              </button>
+              {feedbackMessage ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-800"
+                >
+                  {feedbackMessage}
+                </div>
+              ) : null}
+
+              {feedbackError ? (
+                <div
+                  role="alert"
+                  className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700"
+                >
+                  {feedbackError}
+                </div>
+              ) : null}
+
+              <div className="space-y-3">
+                <button
+                  type="button"
+                  onClick={handleToggleSave}
+                  disabled={saveLoading}
+                  className="w-full rounded-full bg-teal-700 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-teal-700/20 transition hover:bg-teal-600 disabled:opacity-60"
+                >
+                  {saveLoading
+                    ? "Updating..."
+                    : saved
+                      ? "Saved to watchlist"
+                      : "Save listing"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAnalyzeListing}
+                  disabled={analysisLoading}
+                  className="w-full rounded-full border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50 disabled:opacity-60"
+                >
+                  {analysisLoading ? "Analyzing..." : "Analyze listing"}
+                </button>
+                <Link
+                  href={`/booking?listingId=${encodeURIComponent(listing.id)}`}
+                  className="block w-full rounded-full bg-teal-700 px-5 py-3 text-center text-sm font-semibold text-white shadow-lg shadow-teal-700/20 transition hover:bg-teal-600"
+                >
+                  Start booking
+                </Link>
+                <button
+                  type="button"
+                  disabled
+                  className="w-full rounded-full border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-medium text-slate-500"
+                >
+                  Message landlord — coming soon
+                </button>
+              </div>
+              {analysisText ? (
+                <div className="mt-4 rounded-[1.5rem] border border-teal-100 bg-teal-50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-700">
+                    Listing analysis
+                  </p>
+
+                  <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                    {analysisText}
+                  </p>
+                </div>
+              ) : null}
             </div>
           </aside>
         </section>
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 p-4 backdrop-blur lg:hidden">
+          <div className="mx-auto flex max-w-6xl gap-3">
+            <button
+              type="button"
+              onClick={handleToggleSave}
+              disabled={saveLoading}
+              className="flex-1 rounded-full border border-slate-300 bg-white px-4 py-3 text-sm font-medium text-slate-800"
+            >
+              {saved ? "Saved" : "Save"}
+            </button>
+
+            <Link
+              href={`/booking?listingId=${encodeURIComponent(listing.id)}`}
+              className="flex-1 rounded-full bg-teal-700 px-4 py-3 text-center text-sm font-semibold text-white"
+            >
+              Book
+            </Link>
+          </div>
+        </div>
       </main>
     </div>
   );

--- a/webapp/app/listings/[id]/page.tsx
+++ b/webapp/app/listings/[id]/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import Link from "next/link";
+import { notFound, useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { getListing, type ListingJson } from "@/lib/api";
+import { getStoredEmail } from "@/lib/auth-storage";
+import { Nav } from "@/components/Nav";
+import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
+
+function formatPrice(cents: number) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatAmenity(amenity: string) {
+  return amenity.replaceAll("_", " ");
+}
+
+function ListingDetailSkeleton() {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.14),_transparent_28%),linear-gradient(180deg,_#f8fffd_0%,_#ffffff_34%,_#f8fafc_100%)] text-slate-900">
+      <Nav email={getStoredEmail()} />
+
+      <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-14">
+        <div className="rounded-[2rem] border border-slate-200 bg-white p-8 shadow-sm">
+          <p className="text-sm font-medium text-slate-500">
+            Loading listing details…
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ListingDetailPageContent({ listing }: { listing: ListingJson }) {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.14),_transparent_28%),linear-gradient(180deg,_#f8fffd_0%,_#ffffff_34%,_#f8fafc_100%)] text-slate-900">
+      <Nav email={getStoredEmail()} />
+
+      <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-14">
+        <Link
+          href="/listings"
+          className="text-sm font-medium text-teal-700 transition hover:text-teal-600 hover:underline"
+        >
+          ← Back to listings
+        </Link>
+
+        <section className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
+          <div className="space-y-6">
+            <div className="overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-50 shadow-sm">
+              {listing.latitude != null && listing.longitude != null ? (
+                <GoogleMapEmbed
+                  latitude={listing.latitude}
+                  longitude={listing.longitude}
+                  height={320}
+                  zoom={15}
+                />
+              ) : (
+                <div className="flex h-[320px] items-center justify-center px-6 text-center text-sm text-slate-500">
+                  This listing does not include map coordinates yet.
+                </div>
+              )}
+            </div>
+
+            <section className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+              <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+                Listing overview
+              </p>
+
+              <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    {listing.title}
+                  </h1>
+                  <p className="mt-3 text-sm text-slate-500">
+                    Listing ID{" "}
+                    <span className="font-mono text-xs">{listing.id}</span>
+                  </p>
+                </div>
+
+                <div className="w-fit rounded-full bg-teal-50 px-4 py-2 text-base font-semibold text-teal-700">
+                  {formatPrice(listing.price_cents)}
+                </div>
+              </div>
+
+              <div className="mt-6 flex flex-wrap gap-2 text-xs text-slate-600">
+                {listing.smoke_free && (
+                  <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                    Smoke-free
+                  </span>
+                )}
+                {listing.pet_friendly && (
+                  <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                    Pet-friendly
+                  </span>
+                )}
+                {listing.furnished && (
+                  <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                    Furnished
+                  </span>
+                )}
+                {listing.amenities?.map((amenity) => (
+                  <span
+                    key={amenity}
+                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1"
+                  >
+                    {formatAmenity(amenity)}
+                  </span>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+              <h2 className="text-2xl font-semibold tracking-tight text-slate-950">
+                Description
+              </h2>
+              <p className="mt-4 whitespace-pre-wrap leading-7 text-slate-600">
+                {listing.description?.trim() ||
+                  "No description has been provided for this listing yet."}
+              </p>
+            </section>
+          </div>
+
+          <aside className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm lg:sticky lg:top-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.22em] text-teal-700">
+              Renter actions
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+              Next steps
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Save this listing, analyze the fit, or continue toward booking
+              once backend support is available.
+            </p>
+
+            <div className="mt-6 space-y-3">
+              <button
+                type="button"
+                disabled
+                className="w-full rounded-full bg-teal-700 px-5 py-3 text-sm font-semibold text-white opacity-60"
+              >
+                Save listing
+              </button>
+              <button
+                type="button"
+                disabled
+                className="w-full rounded-full border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-800 opacity-60"
+              >
+                Analyze listing
+              </button>
+              <Link
+                href={`/booking?listingId=${encodeURIComponent(listing.id)}`}
+                className="block w-full rounded-full border border-slate-300 bg-white px-5 py-3 text-center text-sm font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50"
+              >
+                Start booking
+              </Link>
+              <button
+                type="button"
+                disabled
+                className="w-full rounded-full border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-medium text-slate-500"
+              >
+                Message landlord — coming soon
+              </button>
+            </div>
+          </aside>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default function ListingDetailPage() {
+  const params = useParams<{ id?: string }>();
+  const listingId = params.id;
+
+  const [listing, setListing] = useState<ListingJson | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [shouldNotFound, setShouldNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!listingId) {
+      setShouldNotFound(true);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setShouldNotFound(false);
+
+    void getListing(listingId)
+      .then((nextListing) => {
+        if (cancelled) return;
+        setListing(nextListing);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setShouldNotFound(true);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [listingId]);
+
+  if (loading) return <ListingDetailSkeleton />;
+
+  if (shouldNotFound || !listing) {
+    notFound();
+  }
+
+  return <ListingDetailPageContent listing={listing} />;
+}

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -162,7 +162,7 @@ function ListingsResultsSection({
   return (
     <section
       data-testid="listings-results"
-      className="mt-10"
+      className="mt-12"
       aria-busy={searchLoading}
       aria-live="polite"
     >
@@ -190,7 +190,7 @@ function ListingsResultsSection({
       </div>
       <div className="mt-8">
         {searchLoading ? (
-          <div className="rounded-[1.75rem] border border-slate-200 bg-white px-6 py-10 text-center shadow-sm">
+          <div className="rounded-[1.75rem] border border-slate-200 bg-white px-6 py-12 text-center shadow-sm">
             <p className="text-base font-medium text-slate-900">
               Loading listings…
             </p>
@@ -219,7 +219,7 @@ function ListingsResultsSection({
             </p>
           </div>
         ) : (
-          <div className="grid gap-6 lg:grid-cols-2">
+          <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
             {items.map((row) => (
               <ListingCard
                 key={row.id}

--- a/webapp/app/listings/page.tsx
+++ b/webapp/app/listings/page.tsx
@@ -13,8 +13,7 @@ import {
 } from "@/lib/api";
 import { getStoredEmail, getStoredToken } from "@/lib/auth-storage";
 import { Nav } from "@/components/Nav";
-import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
-
+import { ListingCard } from "@/components/listings/ListingCard";
 
 // ---------------------------------------------------------------------------
 // Filter state — single source of truth for all search/filter fields
@@ -35,9 +34,9 @@ type ListingFilters = {
 };
 
 const DEFAULT_FILTERS: ListingFilters = {
-  q: '',
-  minPrice: '',
-  maxPrice: '',
+  q: "",
+  minPrice: "",
+  maxPrice: "",
   smokeFree: false,
   petFriendly: false,
   furnishedOnly: false,
@@ -45,19 +44,25 @@ const DEFAULT_FILTERS: ListingFilters = {
   filterParking: false,
   filterLaundry: false,
   filterDishwasher: false,
-  sortBy: 'created_desc',
-  newWithin: '',
+  sortBy: "created_desc",
+  newWithin: "",
 };
 
 type FilterAction =
-  | { type: 'SET'; payload: Partial<ListingFilters> }
-  | { type: 'RESET' };
+  | { type: "SET"; payload: Partial<ListingFilters> }
+  | { type: "RESET" };
 
-function filtersReducer(state: ListingFilters, action: FilterAction): ListingFilters {
+function filtersReducer(
+  state: ListingFilters,
+  action: FilterAction,
+): ListingFilters {
   switch (action.type) {
-    case 'SET': return { ...state, ...action.payload };
-    case 'RESET': return DEFAULT_FILTERS;
-    default: return state;
+    case "SET":
+      return { ...state, ...action.payload };
+    case "RESET":
+      return DEFAULT_FILTERS;
+    default:
+      return state;
   }
 }
 
@@ -66,45 +71,51 @@ function filtersReducer(state: ListingFilters, action: FilterAction): ListingFil
 // ---------------------------------------------------------------------------
 function filtersToParams(f: ListingFilters): URLSearchParams {
   const p = new URLSearchParams();
-  if (f.q) p.set('q', f.q);
-  if (f.minPrice) p.set('min_price', f.minPrice);
-  if (f.maxPrice) p.set('max_price', f.maxPrice);
-  if (f.smokeFree) p.set('smoke_free', '1');
-  if (f.petFriendly) p.set('pet_friendly', '1');
-  if (f.furnishedOnly) p.set('furnished', '1');
+  if (f.q) p.set("q", f.q);
+  if (f.minPrice) p.set("min_price", f.minPrice);
+  if (f.maxPrice) p.set("max_price", f.maxPrice);
+  if (f.smokeFree) p.set("smoke_free", "1");
+  if (f.petFriendly) p.set("pet_friendly", "1");
+  if (f.furnishedOnly) p.set("furnished", "1");
   const amenities: string[] = [];
-  if (f.filterGarage) amenities.push('garage');
-  if (f.filterParking) amenities.push('parking');
-  if (f.filterLaundry) amenities.push('in_unit_laundry');
-  if (f.filterDishwasher) amenities.push('dishwasher');
-  if (amenities.length) p.set('amenities', amenities.join('|'));
-  if (f.newWithin) p.set('new_within', f.newWithin);
-  if (f.sortBy && f.sortBy !== 'created_desc') p.set('sort', f.sortBy);
+  if (f.filterGarage) amenities.push("garage");
+  if (f.filterParking) amenities.push("parking");
+  if (f.filterLaundry) amenities.push("in_unit_laundry");
+  if (f.filterDishwasher) amenities.push("dishwasher");
+  if (amenities.length) p.set("amenities", amenities.join("|"));
+  if (f.newWithin) p.set("new_within", f.newWithin);
+  if (f.sortBy && f.sortBy !== "created_desc") p.set("sort", f.sortBy);
   return p;
 }
 
-function safeStr(v: string | null): string { return v?.trim() || ""; }
-function safeBool(v: string | null): boolean { return v === "1"; }
+function safeStr(v: string | null): string {
+  return v?.trim() || "";
+}
+function safeBool(v: string | null): boolean {
+  return v === "1";
+}
 function safeSort(v: string | null): ListingFilters["sortBy"] {
   const safe = ["created_desc", "listed_desc", "price_asc", "price_desc"];
-  return safe.includes(v ?? "") ? (v as ListingFilters["sortBy"]) : "created_desc";
+  return safe.includes(v ?? "")
+    ? (v as ListingFilters["sortBy"])
+    : "created_desc";
 }
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function paramsToFilters(p: URLSearchParams): Partial<ListingFilters> {
-  const amenities = (p.get('amenities') || '').split('|').filter(Boolean);
+  const amenities = (p.get("amenities") || "").split("|").filter(Boolean);
   return {
-    q: p.get('q') || '',
-    minPrice: p.get('min_price') || '',
-    maxPrice: p.get('max_price') || '',
-    smokeFree: safeBool(p.get('smoke_free')),
-    petFriendly: safeBool(p.get('pet_friendly')),
-    furnishedOnly: safeBool(p.get('furnished')),
-    filterGarage: amenities.includes('garage'),
-    filterParking: amenities.includes('parking'),
-    filterLaundry: amenities.includes('in_unit_laundry'),
-    filterDishwasher: amenities.includes('dishwasher'),
-    newWithin: safeStr(p.get('new_within')),
-    sortBy: safeSort(p.get('sort')),
+    q: p.get("q") || "",
+    minPrice: p.get("min_price") || "",
+    maxPrice: p.get("max_price") || "",
+    smokeFree: safeBool(p.get("smoke_free")),
+    petFriendly: safeBool(p.get("pet_friendly")),
+    furnishedOnly: safeBool(p.get("furnished")),
+    filterGarage: amenities.includes("garage"),
+    filterParking: amenities.includes("parking"),
+    filterLaundry: amenities.includes("in_unit_laundry"),
+    filterDishwasher: amenities.includes("dishwasher"),
+    newWithin: safeStr(p.get("new_within")),
+    sortBy: safeSort(p.get("sort")),
   };
 }
 
@@ -164,7 +175,12 @@ function ListingsResultsSection({
             Available listings
           </h2>
         </div>
-        <p className="text-sm text-slate-500" role="status" aria-live="polite" aria-atomic="true">
+        <p
+          className="text-sm text-slate-500"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           {searchLoading
             ? "Updating results…"
             : searchError
@@ -205,77 +221,10 @@ function ListingsResultsSection({
         ) : (
           <div className="grid gap-6 lg:grid-cols-2">
             {items.map((row) => (
-              <article
+              <ListingCard
                 key={row.id}
-                className="rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <p className="text-xl font-semibold text-slate-900">
-                      {row.title}
-                    </p>
-                    <p className="mt-2 text-sm text-slate-500">
-                      Listing ID{" "}
-                      <span className="font-mono text-xs text-slate-500">
-                        {row.id}
-                      </span>
-                    </p>
-                  </div>
-                  <div className="rounded-full bg-teal-50 px-3 py-1 text-sm font-semibold text-teal-700">
-                    ${(row.price_cents / 100).toFixed(2)}
-                  </div>
-                </div>
-
-                <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-600">
-                  {row.smoke_free && (
-                    <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                      Smoke-free
-                    </span>
-                  )}
-                  {row.pet_friendly && (
-                    <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                      Pet-friendly
-                    </span>
-                  )}
-                  {row.furnished && (
-                    <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                      Furnished
-                    </span>
-                  )}
-                  {row.amenities?.map((amenity) => (
-                    <span
-                      key={amenity}
-                      className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1"
-                    >
-                      {amenity.replaceAll("_", " ")}
-                    </span>
-                  ))}
-                </div>
-
-                <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-500">
-                  {row.listed_at && <span>Listed {row.listed_at}</span>}
-                  {row.latitude != null && row.longitude != null ? (
-                    <span>Map preview available</span>
-                  ) : (
-                    <span>No coordinates provided</span>
-                  )}
-                </div>
-
-                <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
-                  {row.latitude != null && row.longitude != null ? (
-                    <GoogleMapEmbed
-                      latitude={row.latitude}
-                      longitude={row.longitude}
-                      height={180}
-                      zoom={15}
-                    />
-                  ) : (
-                    <div className="flex h-[180px] items-center justify-center px-6 text-center text-sm text-slate-500">
-                      This listing does not include map coordinates yet.
-                    </div>
-                  )}
-                </div>
-              </article>
+                listing={row}
+              />
             ))}
           </div>
         )}
@@ -395,7 +344,10 @@ function ListingsSearchSection({
         </p>
         <div className="mt-3 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           <div className="md:col-span-2">
-            <label htmlFor="listings-q" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label
+              htmlFor="listings-q"
+              className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            >
               Keywords
             </label>
             <input
@@ -408,7 +360,10 @@ function ListingsSearchSection({
             />
           </div>
           <div>
-            <label htmlFor="listings-min-price" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label
+              htmlFor="listings-min-price"
+              className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            >
               Min price (USD)
             </label>
             <input
@@ -421,7 +376,10 @@ function ListingsSearchSection({
             />
           </div>
           <div>
-            <label htmlFor="listings-max-price" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label
+              htmlFor="listings-max-price"
+              className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            >
               Max price (USD)
             </label>
             <input
@@ -511,7 +469,10 @@ function ListingsSearchSection({
         </p>
         <div className="mt-3 flex flex-wrap items-end gap-4">
           <div>
-            <label htmlFor="listings-sort" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label
+              htmlFor="listings-sort"
+              className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            >
               Sort by
             </label>
             <select
@@ -528,7 +489,10 @@ function ListingsSearchSection({
             </select>
           </div>
           <div>
-            <label htmlFor="listings-new-within" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <label
+              htmlFor="listings-new-within"
+              className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            >
               Listed recently
             </label>
             <select
@@ -845,22 +809,48 @@ function ListingsPageInner() {
   const [email, setEmail] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
-  const [filters, dispatchFilters] = useReducer(filtersReducer, DEFAULT_FILTERS);
-  const { q, minPrice, maxPrice, smokeFree, petFriendly, furnishedOnly,
-    filterGarage, filterParking, filterLaundry, filterDishwasher,
-    sortBy, newWithin } = filters;
-  const setQ = (v: string) => dispatchFilters({ type: 'SET', payload: { q: v } });
-  const setMinPrice = (v: string) => dispatchFilters({ type: 'SET', payload: { minPrice: v } });
-  const setMaxPrice = (v: string) => dispatchFilters({ type: 'SET', payload: { maxPrice: v } });
-  const setSmokeFree = (v: boolean) => dispatchFilters({ type: 'SET', payload: { smokeFree: v } });
-  const setPetFriendly = (v: boolean) => dispatchFilters({ type: 'SET', payload: { petFriendly: v } });
-  const setFurnishedOnly = (v: boolean) => dispatchFilters({ type: 'SET', payload: { furnishedOnly: v } });
-  const setFilterGarage = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterGarage: v } });
-  const setFilterParking = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterParking: v } });
-  const setFilterLaundry = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterLaundry: v } });
-  const setFilterDishwasher = (v: boolean) => dispatchFilters({ type: 'SET', payload: { filterDishwasher: v } });
-  const setSortBy = (v: ListingSearchSort) => dispatchFilters({ type: 'SET', payload: { sortBy: v } });
-  const setNewWithin = (v: string) => dispatchFilters({ type: 'SET', payload: { newWithin: v } });
+  const [filters, dispatchFilters] = useReducer(
+    filtersReducer,
+    DEFAULT_FILTERS,
+  );
+  const {
+    q,
+    minPrice,
+    maxPrice,
+    smokeFree,
+    petFriendly,
+    furnishedOnly,
+    filterGarage,
+    filterParking,
+    filterLaundry,
+    filterDishwasher,
+    sortBy,
+    newWithin,
+  } = filters;
+  const setQ = (v: string) =>
+    dispatchFilters({ type: "SET", payload: { q: v } });
+  const setMinPrice = (v: string) =>
+    dispatchFilters({ type: "SET", payload: { minPrice: v } });
+  const setMaxPrice = (v: string) =>
+    dispatchFilters({ type: "SET", payload: { maxPrice: v } });
+  const setSmokeFree = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { smokeFree: v } });
+  const setPetFriendly = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { petFriendly: v } });
+  const setFurnishedOnly = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { furnishedOnly: v } });
+  const setFilterGarage = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { filterGarage: v } });
+  const setFilterParking = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { filterParking: v } });
+  const setFilterLaundry = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { filterLaundry: v } });
+  const setFilterDishwasher = (v: boolean) =>
+    dispatchFilters({ type: "SET", payload: { filterDishwasher: v } });
+  const setSortBy = (v: ListingSearchSort) =>
+    dispatchFilters({ type: "SET", payload: { sortBy: v } });
+  const setNewWithin = (v: string) =>
+    dispatchFilters({ type: "SET", payload: { newWithin: v } });
 
   const [items, setItems] = useState<ListingJson[]>([]);
   const [detail, setDetail] = useState<ListingJson | null>(null);
@@ -901,7 +891,7 @@ function ListingsPageInner() {
   useEffect(() => {
     const params = filtersToParams(debouncedFilters);
     const qs = params.toString();
-    router.replace(qs ? `/listings?${qs}` : '/listings', { scroll: false });
+    router.replace(qs ? `/listings?${qs}` : "/listings", { scroll: false });
   }, [debouncedFilters]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const buildCreateAmenities = (): string[] => {
@@ -1051,7 +1041,12 @@ function ListingsPageInner() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-teal-50/30 text-slate-900">
-      <a href="#listings-results" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:bg-teal-700 focus:px-4 focus:py-2 focus:text-white focus:text-sm focus:font-semibold">Skip to listings</a>
+      <a
+        href="#listings-results"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:bg-teal-700 focus:px-4 focus:py-2 focus:text-white focus:text-sm focus:font-semibold"
+      >
+        Skip to listings
+      </a>
       <Nav email={email} />
       <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-12">
         <ListingsHeaderSection />

--- a/webapp/components/listings/ListingCard.tsx
+++ b/webapp/components/listings/ListingCard.tsx
@@ -12,12 +12,12 @@ function formatAmenity(amenity: string) {
 
 export function ListingCard({ listing }: { listing: ListingJson }) {
   return (
-    <article className="rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md">
+    <article className="flex h-full flex-col rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md">
       <div className="flex items-start justify-between gap-4">
         <div>
           <Link
             href={`/listings/${encodeURIComponent(listing.id)}`}
-            className="text-xl font-semibold text-slate-900 transition hover:text-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+            className="line-clamp-2 text-xl font-semibold text-slate-900 transition hover:text-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
           >
             {listing.title}
           </Link>
@@ -69,7 +69,7 @@ export function ListingCard({ listing }: { listing: ListingJson }) {
         )}
       </div>
 
-      <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
+      <div className="mt-5 overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
         {listing.latitude != null && listing.longitude != null ? (
           <GoogleMapEmbed
             latitude={listing.latitude}

--- a/webapp/components/listings/ListingCard.tsx
+++ b/webapp/components/listings/ListingCard.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { GoogleMapEmbed } from "@/components/GoogleMapEmbed";
+import type { ListingJson } from "@/lib/api";
+
+function formatPrice(cents: number) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatAmenity(amenity: string) {
+  return amenity.replaceAll("_", " ");
+}
+
+export function ListingCard({ listing }: { listing: ListingJson }) {
+  return (
+    <article className="rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <Link
+            href={`/listings/${encodeURIComponent(listing.id)}`}
+            className="text-xl font-semibold text-slate-900 transition hover:text-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            {listing.title}
+          </Link>
+          <p className="mt-2 text-sm text-slate-500">
+            Listing ID{" "}
+            <span className="font-mono text-xs text-slate-500">
+              {listing.id}
+            </span>
+          </p>
+        </div>
+
+        <div className="rounded-full bg-teal-50 px-3 py-1 text-sm font-semibold text-teal-700">
+          {formatPrice(listing.price_cents)}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-600">
+        {listing.smoke_free && (
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+            Smoke-free
+          </span>
+        )}
+        {listing.pet_friendly && (
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+            Pet-friendly
+          </span>
+        )}
+        {listing.furnished && (
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+            Furnished
+          </span>
+        )}
+        {listing.amenities?.map((amenity) => (
+          <span
+            key={amenity}
+            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 capitalize"
+          >
+            {formatAmenity(amenity)}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-500">
+        {listing.listed_at && <span>Listed {listing.listed_at}</span>}
+        {listing.latitude != null && listing.longitude != null ? (
+          <span>Map preview available</span>
+        ) : (
+          <span>No coordinates provided</span>
+        )}
+      </div>
+
+      <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
+        {listing.latitude != null && listing.longitude != null ? (
+          <GoogleMapEmbed
+            latitude={listing.latitude}
+            longitude={listing.longitude}
+            height={180}
+            zoom={15}
+          />
+        ) : (
+          <div className="flex h-[180px] items-center justify-center px-6 text-center text-sm text-slate-500">
+            This listing does not include map coordinates yet.
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/webapp/e2e/listings-detail.spec.ts
+++ b/webapp/e2e/listings-detail.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+
+const listing = {
+  id: "11111111-1111-4111-8111-111111111111",
+  user_id: "user-1",
+  title: "Sunny 2BR near campus",
+  description: "Bright apartment with in-unit laundry and parking.",
+  price_cents: 220000,
+  amenities: ["parking", "in_unit_laundry"],
+  smoke_free: true,
+  pet_friendly: true,
+  furnished: false,
+  listed_at: "2026-05-01",
+  latitude: null,
+  longitude: null,
+};
+
+test.describe("listings marketplace detail flow", () => {
+  test("navigates from listings grid to listing detail page", async ({
+    page,
+  }) => {
+    await page.route("**/api/listings/search**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [listing] }),
+      });
+    });
+
+    await page.route(
+      `**/api/listings/listings/${listing.id}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(listing),
+        });
+      },
+    );
+
+    await page.goto("/listings");
+
+    await expect(page.getByText("Sunny 2BR near campus")).toBeVisible();
+
+    await page.getByRole("link", { name: "Sunny 2BR near campus" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/listings/${listing.id}$`));
+    await expect(
+      page.getByRole("heading", { name: listing.title }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Bright apartment with in-unit laundry and parking."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Save listing" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Analyze listing" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Start booking" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Message landlord/i }),
+    ).toBeDisabled();
+  });
+
+  test("shows feedback when saving requires login", async ({ page }) => {
+    await page.route(
+      `**/api/listings/listings/${listing.id}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(listing),
+        });
+      },
+    );
+
+    await page.goto(`/listings/${listing.id}`);
+
+    await page.getByRole("button", { name: "Save listing" }).click();
+
+    await expect(page.getByRole("alert")).toContainText(
+      "You must be logged in to save listings.",
+    );
+  });
+
+  test("renders listing analysis from analytics API", async ({ page }) => {
+    await page.route(
+      `**/api/listings/listings/${listing.id}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(listing),
+        });
+      },
+    );
+
+    await page.route(
+      "**/api/analytics/insights/listing-feel",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            analysis_text: "This listing looks like a strong renter fit.",
+            model_used: "test-model",
+          }),
+        });
+      },
+    );
+
+    await page.goto(`/listings/${listing.id}`);
+
+    await page.getByRole("button", { name: "Analyze listing" }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Analyzing..." }),
+    ).toBeVisible();
+    await expect(page.getByText("Listing analysis generated.")).toBeVisible();
+    await expect(
+      page.getByText("This listing looks like a strong renter fit."),
+    ).toBeVisible();
+  });
+
+  test("renders not found state for missing listing", async ({ page }) => {
+    await page.route(
+      "**/api/listings/listings/missing-listing",
+      async (route) => {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "not found" }),
+        });
+      },
+    );
+
+    await page.goto("/listings/missing-listing");
+
+    await expect(
+      page.getByRole("heading", { name: "We could not find that listing." }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Back to listings" }),
+    ).toBeVisible();
+  });
+});

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -47,6 +47,7 @@ const suiteProjects = [
       "listings-filters-maps.spec.ts",
       "search-filters.spec.ts",
       "listings.visual.spec.ts",
+      "listings-detail.spec.ts",
     ],
   },
   {


### PR DESCRIPTION
## Summary

This PR redesigns the listings marketplace experience and introduces a dedicated listing detail route.

The previous `/listings` experience functioned primarily as a dense search/tool page. This update moves the UI toward a more modern marketplace-style browsing experience with improved responsive layouts, clearer visual hierarchy, and a dedicated renter detail flow.

The PR also introduces a shareable `/listings/[id]` route with renter-focused actions and improved mobile UX.

---

## What changed

### Listings marketplace redesign

* Refactored listings results into a reusable `ListingCard` component
* Updated listings layout to use a responsive marketplace-style grid
* Improved card consistency, spacing, and responsive behavior
* Added direct navigation from listing cards to detail pages
* Improved browse-first UX and overall visual hierarchy

### Listing detail route

* Added `/listings/[id]` route
* Added loading + not-found states for detail pages
* Added listing overview and description sections
* Added responsive detail layout with:

  * main content column
  * sticky desktop renter action sidebar
  * mobile sticky action bar

### Renter actions + UX states

* Wired watchlist save/remove actions using existing APIs
* Wired listing analysis using the existing analytics endpoint
* Added loading, success, and error feedback states
* Added graceful “coming soon” messaging for unsupported messaging flows
* Preserved booking flow as navigation-only without introducing fake backend behavior

### Accessibility + responsiveness

* Improved keyboard navigation behavior
* Added visible feedback states using `role="status"` and `role="alert"`
* Improved responsive layouts for mobile/tablet/desktop
* Added mobile sticky CTA behavior for renter actions

### Playwright coverage

* Added Playwright coverage for:

  * listings → detail navigation
  * save feedback flow
  * listing analysis flow
  * not-found detail state
* Added new test file to the `03-listings` Playwright project group

---

## Scope boundaries

This PR intentionally does **not** include:

* backend DTO/schema changes
* new backend endpoints
* messaging backend implementation
* booking availability systems
* reviews/personalization systems
* media gallery infrastructure
* dashboard watchlist redesign

---

## Testing

### Completed

* `npm run lint` ✅
* `npx playwright test --list` ✅

### Notes

* Added new Playwright coverage for listing detail flows
* Full Playwright execution requires the local edge environment (`off-campus-housing.test`) and onboarding infrastructure to be running

Closes #129 
