### PR TITLE
feat(webapp): add skeleton loading states for trust page

### DIFF
--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -24,6 +24,31 @@ function TrustHeaderSection() {
   );
 }
 
+function SkeletonLine({ className = "" }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse rounded-md bg-slate-200 ${className}`}
+    />
+  );
+}
+
+function ReputationSkeleton() {
+  return (
+    <div
+      data-testid="trust-reputation-skeleton"
+      className="mt-4 rounded-xl border border-slate-100 bg-slate-50 p-4"
+      aria-hidden="true"
+    >
+      <SkeletonLine className="h-4 w-32" />
+
+      <SkeletonLine className="mt-3 h-7 w-24" />
+
+      <SkeletonLine className="mt-3 h-3 w-48" />
+    </div>
+  );
+}
+
 function ReputationSection({
   repUserId,
   setRepUserId,
@@ -86,13 +111,17 @@ function ReputationSection({
           Use my account id
         </button>
       )}
-      {repScore != null && (
-        <p
-          data-testid="trust-reputation-score"
-          className="mt-4 text-sm text-slate-600"
-        >
-          Score: <strong className="text-teal-800">{repScore}</strong>
-        </p>
+      {loading ? (
+        <ReputationSkeleton />
+      ) : (
+        repScore != null && (
+          <p
+            data-testid="trust-reputation-score"
+            className="mt-4 text-sm text-slate-600"
+          >
+            Score: <strong className="text-teal-800">{repScore}</strong>
+          </p>
+        )
       )}
     </section>
   );
@@ -129,6 +158,7 @@ function ReportAbuseSection({
       <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
         Report abuse
       </h2>
+<<<<<<< HEAD
       <form
         onSubmit={onReport}
         aria-busy={loading}
@@ -137,6 +167,10 @@ function ReportAbuseSection({
         <fieldset className="flex gap-4 text-sm text-slate-700">
           <legend className="sr-only">Abuse target type</legend>
 
+=======
+      <form onSubmit={onReport} aria-busy={loading} className="mt-4 space-y-3">
+        <div className="flex gap-4 text-sm text-slate-700">
+>>>>>>> c022107 (feat(webapp): add trust reputation loading skeleton)
           <label className="flex items-center gap-2">
             <input
               type="radio"
@@ -343,10 +377,7 @@ function PeerReviewSection({
 function TrustLoginPrompt() {
   return (
     <div className="mt-10 rounded-[1.25rem] border border-slate-200 bg-white px-5 py-4 text-sm text-slate-600 shadow-sm">
-      <Link
-        href="/login"
-        className="font-medium text-teal-700 hover:underline"
-      >
+      <Link href="/login" className="font-medium text-teal-700 hover:underline">
         Log in
       </Link>{" "}
       to report abuse or submit peer reviews.

--- a/webapp/app/trust/page.tsx
+++ b/webapp/app/trust/page.tsx
@@ -158,7 +158,6 @@ function ReportAbuseSection({
       <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
         Report abuse
       </h2>
-<<<<<<< HEAD
       <form
         onSubmit={onReport}
         aria-busy={loading}
@@ -166,11 +165,6 @@ function ReportAbuseSection({
       >
         <fieldset className="flex gap-4 text-sm text-slate-700">
           <legend className="sr-only">Abuse target type</legend>
-
-=======
-      <form onSubmit={onReport} aria-busy={loading} className="mt-4 space-y-3">
-        <div className="flex gap-4 text-sm text-slate-700">
->>>>>>> c022107 (feat(webapp): add trust reputation loading skeleton)
           <label className="flex items-center gap-2">
             <input
               type="radio"


### PR DESCRIPTION
## What this PR does
Adds skeleton loading UI to the trust page reputation lookup section to improve perceived performance.

## Changes made

### Skeleton components
- Added `SkeletonLine` — a reusable animated pulse placeholder
- Added `ReputationSkeleton` — shows 3 skeleton lines while reputation score is loading

### Reputation section
- Shows `ReputationSkeleton` while `loading` is true
- Hides skeleton and shows actual score once loaded
- No layout shift — skeleton matches the dimensions of the score display

## Why
The reputation lookup had no loading feedback beyond a disabled button. Users had no indication that a request was in progress.

## Fixes
- Closes #118

## Run locally
cd webapp && pnpm dev
# Navigate to /trust and submit a reputation lookup